### PR TITLE
Add pyproject for packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Macrotype
+
+`macrotype` is a small library that helps generate stub (`.pyi`) files from
+existing Python modules. It has no dependencies and works with modern versions
+of Python.

--- a/macrotype/__init__.py
+++ b/macrotype/__init__.py
@@ -1,0 +1,23 @@
+"""Utilities for extracting type information and generating stub files."""
+
+from .pyi_extract import (
+    PyiElement,
+    TypeRenderInfo,
+    PyiVariable,
+    PyiFunction,
+    PyiClass,
+    PyiModule,
+    format_type,
+    find_typevars,
+)
+
+__all__ = [
+    "PyiElement",
+    "TypeRenderInfo",
+    "PyiVariable",
+    "PyiFunction",
+    "PyiClass",
+    "PyiModule",
+    "format_type",
+    "find_typevars",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "macrotype"
+version = "0.1.0"
+description = "Generate .pyi stub files from existing modules"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+authors = [
+    {name = "Kurt Rose", email = "kurt@kurtrose.com"}
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]


### PR DESCRIPTION
## Summary
- add an `__init__` with exports so `macrotype` can be imported as a package
- add `README.md` with a short description
- create a `pyproject.toml` using PEP 621 metadata

## Testing
- `pip install build` *(fails: Could not find a version that satisfies the requirement build)*

------
https://chatgpt.com/codex/tasks/task_e_687e4d76bb3c8329be6da471dc6a5e7b