### PR TITLE
Handle new union syntax

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 from types import ModuleType
+import types
 from typing import Any, Callable, get_type_hints, _GenericAlias, get_origin, get_args
 import inspect
 import typing
@@ -58,6 +59,12 @@ def format_type(tp: Any) -> TypeRenderInfo:
             arg_str = ", ".join(a.text for a in arg_strs)
             return TypeRenderInfo(f"Callable[[{arg_str}], {ret_fmt.text}]", used)
         return TypeRenderInfo("Callable", used)
+
+    if origin is types.UnionType or origin is typing.Union:
+        arg_strs = [format_type(a) for a in args]
+        used.update(*(a.used for a in arg_strs))
+        text = " | ".join(a.text for a in arg_strs)
+        return TypeRenderInfo(text, used)
 
     if origin is typing.Annotated:
         used.add(typing.Annotated)

--- a/tests/all_annotations.pyi
+++ b/tests/all_annotations.pyi
@@ -1,13 +1,12 @@
-from typing import Callable, Union
+from typing import Callable
 from re import Pattern
-from types import UnionType
 
 class AllAnnotations:
     a: list[str]
     b: dict[str, int]
-    c: Union[int, None]
-    d: Union[int, str]
-    e: UnionType[int, str]
+    c: int | None
+    d: int | str
+    e: int | str
     f: Callable[[int, str], bool]
     g: int
     h: Pattern[str]


### PR DESCRIPTION
## Summary
- support the `|` operator when rendering type hints
- update expected stub output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5e0a155883298f96cbf4bf9b86ab