### PR TITLE
Refactor stub generation helpers

### DIFF
--- a/macrotype/__init__.py
+++ b/macrotype/__init__.py
@@ -21,3 +21,22 @@ __all__ = [
     "format_type",
     "find_typevars",
 ]
+from .stubgen import (
+    load_module_from_path,
+    load_module_from_code,
+    stub_lines,
+    write_stub,
+    iter_python_files,
+    process_file,
+    process_directory,
+)
+
+__all__ += [
+    "load_module_from_path",
+    "load_module_from_code",
+    "stub_lines",
+    "write_stub",
+    "iter_python_files",
+    "process_file",
+    "process_directory",
+]

--- a/macrotype/__main__.py
+++ b/macrotype/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/macrotype/cli.py
+++ b/macrotype/cli.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from . import stubgen
+
+
+def _stdout_write(lines: list[str]) -> None:
+    sys.stdout.write("\n".join(lines) + "\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="macrotype")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["-"],
+        help="Files or directories to process or '-' for stdin/stdout",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output directory or file. Use '-' for stdout when processing a single file or stdin.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.paths == ["-"]:
+        code = sys.stdin.read()
+        module = stubgen.load_module_from_code(code, "<stdin>")
+        lines = stubgen.stub_lines(module)
+        if args.output and args.output != "-":
+            stubgen.write_stub(Path(args.output), lines)
+        else:
+            _stdout_write(lines)
+        return 0
+
+    for target in args.paths:
+        path = Path(target)
+        if path.is_file():
+            lines = stubgen.stub_lines(stubgen.load_module_from_path(path))
+            if args.output == "-":
+                _stdout_write(lines)
+            else:
+                dest = Path(args.output) if args.output else path.with_suffix(".pyi")
+                stubgen.write_stub(dest, lines)
+        else:
+            out_dir = Path(args.output) if args.output and args.output != "-" else None
+            stubgen.process_directory(path, out_dir)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/macrotype/stubgen.py
+++ b/macrotype/stubgen.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+from .pyi_extract import PyiModule
+
+
+def load_module_from_path(path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot import {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[path.stem] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def load_module_from_code(code: str, name: str = "<string>") -> ModuleType:
+    module = ModuleType(name)
+    exec(compile(code, name, "exec"), module.__dict__)
+    return module
+
+
+def stub_lines(module: ModuleType) -> list[str]:
+    return PyiModule.from_module(module).render()
+
+
+def write_stub(dest: Path, lines: list[str]) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text("\n".join(lines) + "\n")
+
+
+def iter_python_files(target: Path) -> list[Path]:
+    if target.is_file():
+        return [target]
+    return list(target.rglob("*.py"))
+
+
+def process_file(src: Path, dest: Path | None = None) -> Path:
+    module = load_module_from_path(src)
+    lines = stub_lines(module)
+    dest = dest or src.with_suffix(".pyi")
+    write_stub(dest, lines)
+    return dest
+
+
+def process_directory(directory: Path, out_dir: Path | None = None) -> list[Path]:
+    outputs = []
+    for src in iter_python_files(directory):
+        dest = (out_dir / src.with_suffix(".pyi").name) if out_dir else None
+        outputs.append(process_file(src, dest))
+    return outputs
+
+
+__all__ = [
+    "load_module_from_path",
+    "load_module_from_code",
+    "stub_lines",
+    "write_stub",
+    "iter_python_files",
+    "process_file",
+    "process_directory",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,6 @@ classifiers = [
 
 [tool.setuptools.packages.find]
 where = ["."]
+
+[project.scripts]
+macrotype = "macrotype.cli:main"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+import subprocess
+
+
+def test_cli_stdout(tmp_path):
+    expected = Path(__file__).with_name("all_annotations.pyi").read_text()
+    result = subprocess.run(
+        [sys.executable, "-m", "macrotype", str(Path(__file__).with_name("all_annotations.py")), "-o", "-"],
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+    )
+    assert result.stdout.strip().splitlines() == expected.strip().splitlines()

--- a/tests/test_stubgen.py
+++ b/tests/test_stubgen.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from macrotype.stubgen import process_file, process_directory
+
+
+def test_process_file(tmp_path):
+    src = Path(__file__).with_name("all_annotations.py")
+    dest = tmp_path / "out.pyi"
+    process_file(src, dest)
+    expected = Path(__file__).with_name("all_annotations.pyi").read_text().splitlines()
+    assert dest.read_text().splitlines() == expected
+
+
+def test_process_directory(tmp_path):
+    src_dir = Path(__file__).parent
+    process_directory(src_dir, tmp_path)
+    generated = (tmp_path / "all_annotations.pyi").read_text().splitlines()
+    expected = Path(__file__).with_name("all_annotations.pyi").read_text().splitlines()
+    assert generated == expected


### PR DESCRIPTION
## Summary
- split stub generation helpers into `stubgen` module
- rework CLI to use the new module
- expose stubgen helpers from the package
- add tests for processing files and directories

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e5b0215bc83299a3be01f4e2a45f1