### PR TITLE
Handle NewType alias in stub generation

### DIFF
--- a/tests/all_annotations.py
+++ b/tests/all_annotations.py
@@ -1,8 +1,20 @@
 import re
-from typing import Optional, Union, Callable, TypeVar, Generic, Literal, Annotated, TypedDict, ParamSpec
+from typing import (
+    Optional,
+    Union,
+    Callable,
+    TypeVar,
+    Generic,
+    Literal,
+    Annotated,
+    TypedDict,
+    ParamSpec,
+    NewType,
+)
 
 T = TypeVar("T")
 P = ParamSpec("P")
+UserId = NewType("UserId", int)
 
 class AllAnnotations:
     a: list[str]
@@ -13,6 +25,7 @@ class AllAnnotations:
     f: Callable[[int, str], bool]
     g: Annotated[int, "meta"]
     h: re.Pattern[str]
+    uid: UserId
     def copy(self, param: T) -> T: ...
     def curry(self, f: Callable[P, int]) -> Callable[P, int]: ...
 

--- a/tests/all_annotations.pyi
+++ b/tests/all_annotations.pyi
@@ -1,5 +1,7 @@
-from typing import Callable
+from typing import Callable, NewType
 from re import Pattern
+
+UserId = NewType('UserId', int)
 
 class AllAnnotations:
     a: list[str]
@@ -10,6 +12,7 @@ class AllAnnotations:
     f: Callable[[int, str], bool]
     g: int
     h: Pattern[str]
+    uid: UserId
     def copy[T](param: T) -> T: ...
     def curry[P](f: Callable[P, int]) -> Callable[P, int]: ...
     class Nested:

--- a/tests/test_pyi_extract.py
+++ b/tests/test_pyi_extract.py
@@ -5,11 +5,13 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from macrotype.pyi_extract import PyiModule
-import tests.all_annotations as all_annotations
+from macrotype.stubgen import load_module_from_path
 
 
 def test_stub_generation_matches_expected():
-    module = PyiModule.from_module(all_annotations)
+    src = Path(__file__).with_name("all_annotations.py")
+    loaded = load_module_from_path(src)
+    module = PyiModule.from_module(loaded)
     generated = module.render()
 
     expected_path = Path(__file__).with_name("all_annotations.pyi")


### PR DESCRIPTION
## Summary
- introduce `PyiAlias` element for representing alias assignments
- detect `typing.NewType` constructs when extracting module stubs
- render NewType aliases and resolve their references correctly
- update `tests/all_annotations.pyi` to expect the alias definition

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687e66b381b083299bb4567a24f60607