### PR TITLE
Support TYPE_CHECKING blocks in stub generation

### DIFF
--- a/macrotype/stubgen.py
+++ b/macrotype/stubgen.py
@@ -4,23 +4,111 @@ import importlib.util
 import sys
 from pathlib import Path
 from types import ModuleType
+import ast
+import typing
+
+
+class _TypeCheckingTransformer(ast.NodeTransformer):
+    """Rewrite ``if TYPE_CHECKING`` blocks to execute their body."""
+
+    @staticmethod
+    def _is_type_checking(expr: ast.expr) -> bool:
+        # ``if TYPE_CHECKING:`` or ``if typing.TYPE_CHECKING:``
+        if isinstance(expr, ast.Name) and expr.id == "TYPE_CHECKING":
+            return True
+        return (
+            isinstance(expr, ast.Attribute)
+            and isinstance(expr.value, ast.Name)
+            and expr.value.id == "typing"
+            and expr.attr == "TYPE_CHECKING"
+        )
+
+    def visit_If(self, node: ast.If) -> ast.stmt:
+        self.generic_visit(node)
+        if self._is_type_checking(node.test):
+            # Execute the body and ignore the else branch. Errors while
+            # executing the body (e.g. ImportError due to circular imports)
+            # are suppressed so stub generation can proceed.
+            return ast.Try(
+                body=node.body,
+                handlers=[
+                    ast.ExceptHandler(
+                        type=ast.Name("Exception", ast.Load()),
+                        name=None,
+                        body=[ast.Pass()],
+                    )
+                ],
+                orelse=[],
+                finalbody=[],
+            )
+        return node
 
 from .pyi_extract import PyiModule
 
 
-def load_module_from_path(path: Path) -> ModuleType:
-    spec = importlib.util.spec_from_file_location(path.stem, path)
-    if spec is None or spec.loader is None:
-        raise ImportError(f"Cannot import {path}")
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[path.stem] = module
-    spec.loader.exec_module(module)
+def _exec_with_type_checking(code: str, module: ModuleType) -> None:
+    """Execute *code* in *module* with ``TYPE_CHECKING`` blocks enabled."""
+    tree = ast.parse(code)
+    tree = _TypeCheckingTransformer().visit(tree)
+    ast.fix_missing_locations(tree)
+
+    module.__dict__["TYPE_CHECKING"] = True
+    original = typing.TYPE_CHECKING
+    typing.TYPE_CHECKING = True
+    try:
+        exec(compile(tree, getattr(module, "__file__", "<string>"), "exec"), module.__dict__)
+    finally:
+        typing.TYPE_CHECKING = original
+
+
+def load_module_from_path(
+    path: Path,
+    *,
+    type_checking: bool = False,
+    module_name: str | None = None,
+) -> ModuleType:
+    """Load a module from ``path``.
+
+    When ``type_checking`` is ``True`` the module is executed with
+    ``TYPE_CHECKING`` blocks enabled and their contents executed.
+
+    ``module_name`` controls the name used in :data:`sys.modules` and defaults
+    to ``path.stem``.
+    """
+    name = module_name or path.stem
+
+    if not type_checking:
+        spec = importlib.util.spec_from_file_location(name, path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot import {path}")
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        return module
+
+    code = Path(path).read_text()
+    module = ModuleType(name)
+    module.__file__ = str(path)
+    sys.modules[name] = module
+    _exec_with_type_checking(code, module)
     return module
 
 
-def load_module_from_code(code: str, name: str = "<string>") -> ModuleType:
+def load_module_from_code(
+    code: str,
+    name: str = "<string>",
+    *,
+    type_checking: bool = False,
+    module_name: str | None = None,
+) -> ModuleType:
+    name = module_name or name
     module = ModuleType(name)
-    exec(compile(code, name, "exec"), module.__dict__)
+    if type_checking:
+        sys.modules[name] = module
+        _exec_with_type_checking(code, module)
+    else:
+        sys.modules[name] = module
+        exec(compile(code, name, "exec"), module.__dict__)
     return module
 
 

--- a/tests/circ_a.py
+++ b/tests/circ_a.py
@@ -1,0 +1,12 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tests.circ_b import B
+else:
+    B = int
+
+class A:
+    pass
+
+def takes_b(x: 'B') -> None:
+    pass

--- a/tests/circ_a.pyi
+++ b/tests/circ_a.pyi
@@ -1,0 +1,6 @@
+from tests.circ_b import B
+
+class A:
+    pass
+
+def takes_b(x: B) -> None: ...

--- a/tests/circ_b.py
+++ b/tests/circ_b.py
@@ -1,0 +1,12 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tests.circ_a import A
+else:
+    A = int
+
+class B:
+    pass
+
+def takes_a(x: 'A') -> None:
+    pass

--- a/tests/circ_b.pyi
+++ b/tests/circ_b.pyi
@@ -1,0 +1,6 @@
+from tests.circ_a import A
+
+class B:
+    pass
+
+def takes_a(x: A) -> None: ...

--- a/tests/test_type_checking.py
+++ b/tests/test_type_checking.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from macrotype.stubgen import load_module_from_path, stub_lines
+
+
+def test_if_type_checking_overrides():
+    mod = load_module_from_path(Path(__file__).with_name("typechecking.py"), type_checking=True)
+    lines = stub_lines(mod)
+    expected = Path(__file__).with_name("typechecking.pyi").read_text().splitlines()
+    assert lines == expected
+
+
+def test_circular_type_checking_imports():
+    base = Path(__file__)
+    mod_b = load_module_from_path(base.with_name("circ_b.py"), type_checking=True, module_name="tests.circ_b")
+    mod_a = load_module_from_path(base.with_name("circ_a.py"), type_checking=True, module_name="tests.circ_a")
+
+    lines = stub_lines(mod_a)
+    expected = base.with_name("circ_a.pyi").read_text().splitlines()
+    assert lines == expected

--- a/tests/typechecking.py
+++ b/tests/typechecking.py
@@ -1,0 +1,10 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tests.all_annotations import AllAnnotations
+else:
+    AllAnnotations = int
+
+
+def takes(x: 'AllAnnotations') -> None:
+    pass

--- a/tests/typechecking.pyi
+++ b/tests/typechecking.pyi
@@ -1,0 +1,3 @@
+from tests.all_annotations import AllAnnotations
+
+def takes(x: AllAnnotations) -> None: ...


### PR DESCRIPTION
## Summary
- execute and prefer `if TYPE_CHECKING:` blocks when loading modules
- add helper to transform `if TYPE_CHECKING` statements
- test stub generation with TYPE_CHECKING blocks
- allow specifying module names when loading for stub generation
- test circular TYPE_CHECKING imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e65cd982c83299780e0ec7416361b