### PR TITLE
Add tests for __slots__ and overload handling

### DIFF
--- a/tests/all_annotations.py
+++ b/tests/all_annotations.py
@@ -10,6 +10,7 @@ from typing import (
     TypedDict,
     ParamSpec,
     NewType,
+    overload,
 )
 
 T = TypeVar("T")
@@ -43,3 +44,21 @@ class SampleDict(TypedDict):
 class PartialDict(TypedDict, total=False):
     id: int
     hint: str
+
+
+class Slotted:
+    __slots__ = ("x", "y")
+    x: int
+    y: str
+
+
+@overload
+def over(x: int) -> int: ...
+
+
+@overload
+def over(x: str) -> str: ...
+
+
+def over(x: int | str) -> int | str:
+    return x

--- a/tests/all_annotations.pyi
+++ b/tests/all_annotations.pyi
@@ -1,4 +1,4 @@
-from typing import Callable, NewType
+from typing import Callable, NewType, overload
 from re import Pattern
 
 UserId = NewType('UserId', int)
@@ -29,3 +29,15 @@ class SampleDict(TypedDict):
 class PartialDict(TypedDict, total=False):
     id: int
     hint: str
+
+class Slotted:
+    x: int
+    y: str
+
+@overload
+def over(x: int) -> int: ...
+
+@overload
+def over(x: str) -> str: ...
+
+def over(x: int | str) -> int | str: ...


### PR DESCRIPTION
## Summary
- move slot and overload examples into `all_annotations`
- keep overload definitions in stubs via `typing.get_overloads`
- update expected stubs accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e6d2b145483298e79d1d2eed8e317