### PR TITLE
Add Literal edge case test

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -100,7 +100,7 @@ def format_type(tp: Any) -> TypeRenderInfo:
     if hasattr(tp, '_name') and tp._name:
         return TypeRenderInfo(tp._name, used)
 
-    return TypeRenderInfo(str(tp), used)
+    return TypeRenderInfo(repr(tp), used)
 
 
 def find_typevars(tp: Any) -> set[str]:

--- a/tests/all_annotations.py
+++ b/tests/all_annotations.py
@@ -27,8 +27,10 @@ class AllAnnotations:
     g: Annotated[int, "meta"]
     h: re.Pattern[str]
     uid: UserId
+    lit_attr: Literal["a", "b"]
     def copy(self, param: T) -> T: ...
     def curry(self, f: Callable[P, int]) -> Callable[P, int]: ...
+    def literal_method(self, flag: Literal["on", "off"]) -> Literal[1, 0]: ...
 
     class Nested:
         x: float

--- a/tests/all_annotations.pyi
+++ b/tests/all_annotations.pyi
@@ -1,4 +1,4 @@
-from typing import Callable, NewType, overload
+from typing import Callable, Literal, NewType, overload
 from re import Pattern
 
 UserId = NewType('UserId', int)
@@ -13,8 +13,10 @@ class AllAnnotations:
     g: int
     h: Pattern[str]
     uid: UserId
+    lit_attr: Literal['a', 'b']
     def copy[T](param: T) -> T: ...
     def curry[P](f: Callable[P, int]) -> Callable[P, int]: ...
+    def literal_method(flag: Literal['on', 'off']) -> Literal[1, 0]: ...
     class Nested:
         x: float
         y: str


### PR DESCRIPTION
## Summary
- handle quoting of constant values in type rendering
- extend `AllAnnotations` to use `Literal` types
- update expected stub for new members

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e7252be008329b0a3a1d4b502afc2