### PR TITLE
Fix dataclass detection edge cases

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -273,7 +273,8 @@ class PyiClass(PyiElement):
                 bases.append(fmt.text)
                 used_types.update(fmt.used)
 
-        if dataclasses.is_dataclass(klass):
+        is_dataclass_obj = dataclasses.is_dataclass(klass) or hasattr(klass, "__dataclass_fields__")
+        if is_dataclass_obj:
             params = getattr(klass, "__dataclass_params__", None)
             args: list[str] = []
             if params is not None:
@@ -327,7 +328,8 @@ class PyiClass(PyiElement):
                 "__setstate__",
                 "_dataclass_getstate",
                 "_dataclass_setstate",
-            } if dataclasses.is_dataclass(klass) else set()
+                "__getattribute__",
+            } if is_dataclass_obj else set()
 
             for attr_name, attr in klass.__dict__.items():
                 if attr_name in auto_methods:

--- a/tests/nested_dataclass.py
+++ b/tests/nested_dataclass.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+@dataclass
+class Outer:
+    x: int
+    @dataclass
+    class Inner:
+        y: int

--- a/tests/nested_dataclass.pyi
+++ b/tests/nested_dataclass.pyi
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+@dataclass
+class Outer:
+    x: int
+    @dataclass
+    class Inner:
+        y: int

--- a/tests/test_pyi_extract.py
+++ b/tests/test_pyi_extract.py
@@ -30,3 +30,15 @@ def test_dataclass_decorators():
     expected = expected_path.read_text().splitlines()
 
     assert generated == expected
+
+
+def test_nested_dataclass():
+    src = Path(__file__).with_name("nested_dataclass.py")
+    loaded = load_module_from_path(src)
+    module = PyiModule.from_module(loaded)
+    generated = module.render()
+
+    expected_path = Path(__file__).with_name("nested_dataclass.pyi")
+    expected = expected_path.read_text().splitlines()
+
+    assert generated == expected


### PR DESCRIPTION
## Summary
- handle dataclasses detected via `__dataclass_fields__`
- skip generated `__getattribute__` method for dataclasses
- add regression test for nested dataclasses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e872c14988329be86f77d5dda0dd4