### PR TITLE
Improve dataclass and overload handling

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -300,6 +300,8 @@ class PyiClass(PyiElement):
                     "weakref_slot": False,
                 }
                 for name, default in defaults.items():
+                    if name == "match_args" and not hasattr(params, "match_args"):
+                        continue
                     if hasattr(params, name):
                         val = getattr(params, name)
                     else:
@@ -307,8 +309,6 @@ class PyiClass(PyiElement):
                             val = not hasattr(klass, "__dict__")
                         elif name == "weakref_slot":
                             val = "__weakref__" in getattr(klass, "__slots__", ())
-                        elif name == "match_args":
-                            val = hasattr(klass, "__match_args__")
                         else:
                             val = default
                     if val != default:

--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -348,6 +348,7 @@ class PyiClass(PyiElement):
                 "_dataclass_getstate",
                 "_dataclass_setstate",
                 "__getattribute__",
+                "__replace__",
             } if is_dataclass_obj else set()
 
             for attr_name, attr in klass.__dict__.items():

--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -7,6 +7,15 @@ from typing import Any, Callable, get_type_hints, _GenericAlias, get_origin, get
 import functools
 import inspect
 import typing
+
+try:
+    from typing import get_overloads as _get_overloads
+except ImportError:  # pragma: no cover - Python < 3.11
+    try:
+        from typing_extensions import get_overloads as _get_overloads
+    except Exception:  # pragma: no cover - very old typing
+        def _get_overloads(func):
+            return []
 import builtins
 import collections.abc
 
@@ -291,7 +300,17 @@ class PyiClass(PyiElement):
                     "weakref_slot": False,
                 }
                 for name, default in defaults.items():
-                    val = getattr(params, name, default)
+                    if hasattr(params, name):
+                        val = getattr(params, name)
+                    else:
+                        if name == "slots":
+                            val = not hasattr(klass, "__dict__")
+                        elif name == "weakref_slot":
+                            val = "__weakref__" in getattr(klass, "__slots__", ())
+                        elif name == "match_args":
+                            val = hasattr(klass, "__match_args__")
+                        else:
+                            val = default
                     if val != default:
                         args.append(f"{name}={val}")
             deco = "dataclass" + (f"({', '.join(args)})" if args else "")
@@ -335,7 +354,7 @@ class PyiClass(PyiElement):
                 if attr_name in auto_methods:
                     continue
                 if inspect.isfunction(attr):
-                    ovs = typing.get_overloads(attr)
+                    ovs = _get_overloads(attr)
                     if ovs:
                         for ov in ovs:
                             members.append(PyiFunction.from_function(ov, decorators=["overload"]))
@@ -395,7 +414,7 @@ class PyiModule:
             seen[id(obj)] = name
 
             if inspect.isfunction(obj):
-                ovs = typing.get_overloads(obj)
+                ovs = _get_overloads(obj)
                 if ovs:
                     for ov in ovs:
                         ofunc = PyiFunction.from_function(ov, decorators=["overload"])


### PR DESCRIPTION
## Summary
- handle typing.get_overloads for Python < 3.11
- detect dataclass `slots` and `weakref_slot` even when not present in `__dataclass_params__`
- use helper `_get_overloads`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e89a8d2548329a0d64669af8d4286