### PR TITLE
Handle typing.Self annotations

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -66,6 +66,9 @@ def format_type(tp: Any) -> TypeRenderInfo:
 
     if tp is type(None):
         return TypeRenderInfo("None", used)
+    if tp is typing.Self:
+        used.add(typing.Self)
+        return TypeRenderInfo("Self", used)
     if tp is Any:
         used.add(Any)
         return TypeRenderInfo("Any", used)

--- a/tests/self_annotation.py
+++ b/tests/self_annotation.py
@@ -1,0 +1,5 @@
+from typing import Self
+
+class Example:
+    def clone(self: Self) -> Self:
+        return self

--- a/tests/self_annotation.pyi
+++ b/tests/self_annotation.pyi
@@ -1,0 +1,4 @@
+from typing import Self
+
+class Example:
+    def clone(self: Self) -> Self: ...

--- a/tests/test_pyi_extract.py
+++ b/tests/test_pyi_extract.py
@@ -90,3 +90,14 @@ def test_tuple_ellipsis():
     expected = expected_path.read_text().splitlines()
 
     assert generated == expected
+
+def test_self_annotation():
+    src = Path(__file__).with_name("self_annotation.py")
+    loaded = load_module_from_path(src)
+    module = PyiModule.from_module(loaded)
+    generated = module.render()
+
+    expected_path = Path(__file__).with_name("self_annotation.pyi")
+    expected = expected_path.read_text().splitlines()
+
+    assert generated == expected


### PR DESCRIPTION
## Summary
- support `typing.Self` when formatting types
- add regression test for `Self` imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fadcc95408329a23e1f1646a8a486