### PR TITLE
Use Python 3.13 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e '.[test]' pytest
+      - name: Run tests
+        run: |
+          pytest -q


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to test only with Python 3.13

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687fd88f6c9883299756344d38838dd0