### PR TITLE
Add TypedDict NotRequired/Required support

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -542,14 +542,17 @@ class PyiClass(PyiNamedElement):
             used_types.update(used)
 
         raw_ann = klass.__dict__.get("__annotations__", {})
-        try:
-            globalns = vars(inspect.getmodule(klass))
-            resolved = {
-                name: get_type_hints(klass, globalns=globalns, localns=klass.__dict__).get(name, annotation)
-                for name, annotation in raw_ann.items()
-            }
-        except Exception:
+        if is_typeddict:
             resolved = raw_ann
+        else:
+            try:
+                globalns = vars(inspect.getmodule(klass))
+                resolved = {
+                    name: get_type_hints(klass, globalns=globalns, localns=klass.__dict__).get(name, annotation)
+                    for name, annotation in raw_ann.items()
+                }
+            except Exception:
+                resolved = raw_ann
 
         for name, annotation in resolved.items():
             fmt = format_type(annotation)

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -22,6 +22,8 @@ from typing import (
     Tuple,
     Any,
     TypeAlias,
+    NotRequired,
+    Required,
 )
 
 T = TypeVar("T")
@@ -93,6 +95,12 @@ class SampleDict(TypedDict):
 class PartialDict(TypedDict, total=False):
     id: int
     hint: str
+
+
+class MixedDict(TypedDict):
+    required_field: int
+    optional_field: NotRequired[str]
+    required_override: Required[int]
 
 
 class GenericClass(Generic[T]):

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, ClassVar, Literal, NamedTuple, NewType, ParamSpec, Self, TypeVar, TypeVarTuple, TypedDict, Unpack, overload
+from typing import Any, Callable, ClassVar, Literal, NamedTuple, NewType, NotRequired, ParamSpec, Required, Self, TypeVar, TypeVarTuple, TypedDict, Unpack, overload
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from functools import cached_property
@@ -70,6 +70,11 @@ class SampleDict(TypedDict):
 class PartialDict(TypedDict, total=False):
     id: int
     hint: str
+
+class MixedDict(TypedDict):
+    required_field: int
+    optional_field: NotRequired[str]
+    required_override: Required[int]
 
 class GenericClass[T]:
     value: T

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -65,3 +65,13 @@ def test_process_directory(tmp_path, src: str, expected: str) -> None:
     generated = (tmp_path / expected).read_text().splitlines()
     expected_lines = Path(__file__).with_name(expected).read_text().splitlines()
     assert generated == expected_lines
+
+
+def test_mixed_typeddict_support() -> None:
+    src_path = Path(__file__).with_name("annotations.py")
+    loaded = load_module_from_path(src_path)
+    module = PyiModule.from_module(loaded)
+    lines = module.render()
+    assert "class MixedDict(TypedDict):" in lines
+    assert "    optional_field: NotRequired[str]" in lines
+    assert "    required_override: Required[int]" in lines


### PR DESCRIPTION
## Summary
- preserve `NotRequired`/`Required` when extracting TypedDict classes
- add MixedDict example using these annotations
- validate MixedDict output in a dedicated test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687feb81f00883299dea47061c32a20a