### PR TITLE
Handle annotation-only variables in stub generation

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -7,6 +7,7 @@ from typing import (
     Annotated,
     Callable,
     ClassVar,
+    Final,
     NoReturn,
     Never,
     NamedTuple,
@@ -48,6 +49,9 @@ type ListOrSet[T] = list[T] | set[T]
 type IntFunc[**P] = Callable[P, int]
 type LabeledTuple[*Ts] = tuple[str, *Ts]
 type RecursiveList[T] = T | list[RecursiveList[T]]
+
+GLOBAL: int
+CONST: Final[str]
 
 
 class Basic:

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, ClassVar, Literal, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Required, Self, TypeVar, TypeVarTuple, TypedDict, Unpack, overload
+from typing import Any, Callable, ClassVar, Final, Literal, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Required, Self, TypeVar, TypeVarTuple, TypedDict, Unpack, overload
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from functools import cached_property
@@ -165,3 +165,7 @@ def dict_echo(**kwargs: dict[str, Any]) -> dict[str, Any]: ...
 def always_raises() -> NoReturn: ...
 
 def never_returns() -> Never: ...
+
+GLOBAL: int
+
+CONST: Final[str]


### PR DESCRIPTION
## Summary
- handle annotations that don't have assigned values when generating stubs
- consolidate annotation-only variable test into main annotations module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ff11b592c8329a43ac239d42c94ed