### PR TITLE
Add support for `typing.final` decorator

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -482,7 +482,10 @@ class PyiFunction(PyiNamedElement):
                 flat_params = [p for p in flat_params if p.lstrip('*') not in exclude_params]
             tp_strings = flat_params
 
-        decorators = decorators or []
+        decorators = list(decorators or [])
+        if getattr(fn, "__final__", False):
+            decorators.append("final")
+            used_types.add(typing.final)
         if "overload" in decorators:
             used_types.add(typing.overload)
 
@@ -541,6 +544,9 @@ class PyiClass(PyiNamedElement):
         typeddict_total = klass.__dict__.get("__total__", True) if is_typeddict else None
         decorators: list[str] = []
         used_types: set[type] = set()
+        if getattr(klass, "__final__", False):
+            decorators.append("final")
+            used_types.add(typing.final)
         class_params: set[str] = {t.__name__ for t in getattr(klass, '__parameters__', ())}
 
         type_params: list[str] = []

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -31,6 +31,7 @@ from typing import (
     NotRequired,
     Required,
     TypeGuard,
+    final,
 )
 
 T = TypeVar("T")
@@ -320,3 +321,19 @@ def echo_literal(value: LiteralString) -> LiteralString:
 # Edge case: async function
 async def async_add_one(x: int) -> int:
     return x + 1
+
+# Edge case: ``final`` decorator handling
+@final
+def final_func(x: int) -> int:
+    return x
+
+
+@final
+class FinalClass:
+    ...
+
+
+class HasFinalMethod:
+    @final
+    def do_final(self) -> None:
+        pass

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, overload
+from typing import Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from functools import cached_property
@@ -198,6 +198,17 @@ def is_str_list(val: list[object]) -> TypeGuard[list[str]]: ...
 def echo_literal(value: LiteralString) -> LiteralString: ...
 
 async def async_add_one(x: int) -> int: ...
+
+@final
+def final_func(x: int) -> int: ...
+
+@final
+class FinalClass:
+    pass
+
+class HasFinalMethod:
+    @final
+    def do_final(self) -> None: ...
 
 GLOBAL: int
 


### PR DESCRIPTION
## Summary
- recognize `typing.final` on functions and classes
- add tests for `final` decorator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68805ecbdbe8832998bbfa014ea91d73