### PR TITLE
Add dataclass options edge case test

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -192,6 +192,12 @@ class NoAutoEq:
     def __eq__(self, other: object) -> bool:
         return isinstance(other, NoAutoEq) and self.x == other.x
 
+# Dataclass with additional options to test decorator generation
+# ``weakref_slot=True`` requires ``slots=True``
+@dataclass(order=True, match_args=False, slots=True, weakref_slot=True)
+class OptionDataclass:
+    value: int
+
 
 @dataclass
 class Outer:

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -126,6 +126,10 @@ class NoAutoEq:
     x: int
     def __eq__(self, other: object) -> bool: ...
 
+@dataclass(order=True, match_args=False, slots=True, weakref_slot=True)
+class OptionDataclass:
+    value: int
+
 @dataclass
 class Outer:
     x: int


### PR DESCRIPTION
## Summary
- add new dataclass in tests covering order, match_args and weakref_slot
- update expected stub file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688062d557dc832989dfdb0c79200505