### PR TITLE
Add TypeVarTuple alias test

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -64,6 +64,8 @@ type RecursiveList[T] = T | list[RecursiveList[T]]
 AliasListT = TypeAliasType("AliasListT", list[T], type_params=(T,))
 # Edge case: ``TypeAliasType`` used with a ``ParamSpec`` alias
 AliasFuncP = TypeAliasType("AliasFuncP", Callable[P, int], type_params=(P,))
+# Edge case: ``TypeAliasType`` used with a ``TypeVarTuple`` alias
+AliasTupleTs = TypeAliasType("AliasTupleTs", tuple[*Ts], type_params=(Ts,))
 
 GLOBAL: int
 CONST: Final[str]

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -43,6 +43,8 @@ type AliasListT[T] = list[T]
 
 type AliasFuncP[**P] = Callable[P, int]
 
+type AliasTupleTs[*Ts] = tuple[Unpack[Ts]]
+
 class Basic:
     simple: list[str]
     mapping: dict[str, int]


### PR DESCRIPTION
## Summary
- add a `TypeAliasType` case that uses a `TypeVarTuple`
- update expected stub file accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68806f69c2948329b3051319564018b4