### PR TITLE
Add lambda variable handling

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -689,6 +689,8 @@ class PyiClass(PyiNamedElement):
                 if attr_name in auto_methods:
                     continue
                 if inspect.isfunction(attr):
+                    if attr.__name__ == "<lambda>":
+                        continue
                     ovs = _get_overloads(attr)
                     if ovs:
                         for ov in ovs:
@@ -830,6 +832,22 @@ class PyiModule:
             handled_names.add(name)
 
             if inspect.isfunction(obj):
+                if obj.__name__ == "<lambda>":
+                    annotation = resolved_ann.get(name)
+                    if annotation is not None:
+                        fmt = format_type(annotation)
+                        used_types.update(fmt.used)
+                        body.append(
+                            PyiVariable(
+                                name=name,
+                                type_str=fmt.text,
+                                used_types=fmt.used,
+                            )
+                        )
+                    else:
+                        body.append(PyiVariable.from_assignment(name, obj))
+                    continue
+
                 ovs = _get_overloads(obj)
                 if ovs:
                     for ov in ovs:

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -76,6 +76,10 @@ FUNC_ELLIPSIS: Callable[..., int]
 # Variable using tuple ellipsis syntax
 TUPLE_VAR: tuple[int, ...]
 
+# Edge case: lambda expressions should be treated as variables, not functions
+UNTYPED_LAMBDA = lambda x, y: x + y
+TYPED_LAMBDA: Callable[[int, int], int] = lambda a, b: a + b
+
 
 class Basic:
     simple: list[str]

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -45,6 +45,10 @@ type AliasFuncP[**P] = Callable[P, int]
 
 type AliasTupleTs[*Ts] = tuple[Unpack[Ts]]
 
+UNTYPED_LAMBDA: function
+
+TYPED_LAMBDA: Callable[[int, int], int]
+
 class Basic:
     simple: list[str]
     mapping: dict[str, int]


### PR DESCRIPTION
## Summary
- skip lambdas when gathering functions so they produce variable annotations instead
- test lambda handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880729bd5a083298fea0ff9c63e738b