### PR TITLE
Improve TypeVar alias handling

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -903,10 +903,28 @@ class PyiModule:
                     if isinstance(obj, alias_type):
                         alias_used = {alias_type}
                         used_types.update(alias_used)
+                        if isinstance(obj, typing.TypeVar):
+                            args = [f"'{obj.__name__}'"]
+                            if getattr(obj, "__covariant__", False):
+                                args.append("covariant=True")
+                            if getattr(obj, "__contravariant__", False):
+                                args.append("contravariant=True")
+                            if getattr(obj, "__infer_variance__", False):
+                                args.append("infer_variance=True")
+                            value = f"TypeVar({', '.join(args)})"
+                        elif isinstance(obj, typing.ParamSpec):
+                            args = [f"'{obj.__name__}'"]
+                            if getattr(obj, "__covariant__", False):
+                                args.append("covariant=True")
+                            if getattr(obj, "__contravariant__", False):
+                                args.append("contravariant=True")
+                            value = f"ParamSpec({', '.join(args)})"
+                        else:
+                            value = f"{alias_type.__name__}('{obj.__name__}')"
                         body.append(
                             PyiAlias(
                                 name=name,
-                                value=f"{alias_type.__name__}('{obj.__name__}')",
+                                value=value,
                                 used_types=alias_used,
                             )
                         )

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -44,6 +44,9 @@ Ts = TypeVarTuple("Ts")
 U = TypeVar("U", bound=str)
 # Constrained type variable ensures constraint metadata is ignored
 NumberLike = TypeVar("NumberLike", int, float)
+CovariantT = TypeVar("CovariantT", covariant=True)
+ContravariantT = TypeVar("ContravariantT", contravariant=True)
+InferredT = TypeVar("InferredT", infer_variance=True)
 UserId = NewType("UserId", int)
 
 MyList: TypeAlias = list[int]

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -15,6 +15,12 @@ U = TypeVar('U')
 
 NumberLike = TypeVar('NumberLike')
 
+CovariantT = TypeVar('CovariantT', covariant=True)
+
+ContravariantT = TypeVar('ContravariantT', contravariant=True)
+
+InferredT = TypeVar('InferredT', infer_variance=True)
+
 UserId = NewType('UserId', int)
 
 MyList = list[int]


### PR DESCRIPTION
## Summary
- preserve variance annotations when exporting `TypeVar` and `ParamSpec` aliases
- test variance handling via annotations module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68807837a0f08329807d2124b7966aa5