### PR TITLE
Add Annotated metadata support

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -437,7 +437,9 @@ class PyiFunction(PyiNamedElement):
         """Create a :class:`PyiFunction` from ``fn``."""
 
         try:
-            hints = get_type_hints(fn, globalns=globalns, localns=localns)
+            hints = get_type_hints(
+                fn, globalns=globalns, localns=localns, include_extras=True
+            )
         except Exception:
             hints = {}
 
@@ -658,7 +660,12 @@ class PyiClass(PyiNamedElement):
             try:
                 globalns = vars(inspect.getmodule(klass))
                 resolved = {
-                    name: get_type_hints(klass, globalns=globalns, localns=klass.__dict__).get(name, annotation)
+                    name: get_type_hints(
+                        klass,
+                        globalns=globalns,
+                        localns=klass.__dict__,
+                        include_extras=True,
+                    ).get(name, annotation)
                     for name, annotation in raw_ann.items()
                 }
             except Exception:
@@ -803,7 +810,7 @@ class PyiModule:
         globals_dict = vars(mod)
         raw_ann = getattr(mod, "__annotations__", {})
         try:
-            resolved_ann = get_type_hints(mod)
+            resolved_ann = get_type_hints(mod, include_extras=True)
         except Exception:
             resolved_ann = raw_ann
 

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -392,3 +392,7 @@ def iter_sequence(seq: cabc.Sequence[int]) -> cabc.Iterator[int]:
 @functools.lru_cache()
 def cached_add(a: int, b: int) -> int:
     return a + b
+
+# Edge case: ``Annotated`` parameter and return types
+def annotated_fn(x: Annotated[int, "inp"]) -> Annotated[str, "out"]:
+    return str(x)

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,4 +1,4 @@
-from typing import Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload, runtime_checkable
+from typing import Annotated, Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload, runtime_checkable
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from enum import Enum, IntEnum
@@ -62,7 +62,7 @@ class Basic:
     union: int | str
     pipe_union: int | str
     func: Callable[[int, str], bool]
-    annotated: int
+    annotated: Annotated[int, 'meta']
     pattern: Pattern[str]
     uid: UserId
     lit_attr: Literal['a', 'b']
@@ -248,6 +248,8 @@ def pos_and_kw(a: int, /, b: int, *, c: int) -> None: ...
 def iter_sequence(seq: Sequence[int]) -> Iterator[int]: ...
 
 def cached_add(a: int, b: int) -> int: ...
+
+def annotated_fn(x: Annotated[int, 'inp']) -> Annotated[str, 'out']: ...
 
 GLOBAL: int
 


### PR DESCRIPTION
## Summary
- preserve annotated metadata using `include_extras=True`
- test annotated parameter and return handling in stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68807db727a48329b6eb854a60966d71