### PR TITLE
Handle dataclasses InitVar

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -672,6 +672,8 @@ class PyiClass(PyiNamedElement):
                 resolved = raw_ann
 
         for name, annotation in resolved.items():
+            if is_dataclass_obj and isinstance(annotation, dataclasses.InitVar):
+                continue
             fmt = format_type(annotation)
             members.append(
                 PyiVariable(name=name, type_str=fmt.text, used_types=fmt.used)

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -2,7 +2,7 @@ import re
 import sys
 import functools
 from functools import cached_property
-from dataclasses import dataclass
+from dataclasses import dataclass, InitVar
 from enum import Enum, IntEnum
 import collections.abc as cabc
 from typing import (
@@ -226,6 +226,16 @@ class NoAutoEq:
 @dataclass(order=True, match_args=False, slots=True, weakref_slot=True)
 class OptionDataclass:
     value: int
+
+
+# Edge case: dataclasses.InitVar fields should not appear in stubs
+@dataclass
+class InitVarExample:
+    x: int
+    init_only: InitVar[int]
+
+    def __post_init__(self, init_only: int) -> None:
+        self.x += init_only
 
 
 @dataclass

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -152,6 +152,11 @@ class OptionDataclass:
     value: int
 
 @dataclass
+class InitVarExample:
+    x: int
+    def __post_init__(self, init_only: int) -> None: ...
+
+@dataclass
 class Outer:
     x: int
     @dataclass


### PR DESCRIPTION
## Summary
- skip dataclasses.InitVar fields when generating stubs
- add InitVarExample dataclass to annotation fixtures
- expect InitVarExample in annotations.pyi without the InitVar field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68808e101d508329bcb6ef2488c02d99