### PR TITLE
Add TypeAliasType parameter support

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -874,12 +874,9 @@ class PyiModule:
                 used_types.update(fmt.used)
                 params = []
                 for tp in getattr(obj, "__type_params__", ()):  # pragma: no cover - py312
-                    if isinstance(tp, typing.TypeVar):
-                        params.append(tp.__name__)
-                    elif isinstance(tp, typing.ParamSpec):
-                        params.append(f"**{tp.__name__}")
-                    elif isinstance(tp, typing.TypeVarTuple):
-                        params.append(f"*{tp.__name__}")
+                    fmt_tp = format_type_param(tp)
+                    params.append(fmt_tp.text)
+                    used_types.update(fmt_tp.used)
                 body.append(
                     PyiAlias(
                         name=name,

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -72,6 +72,9 @@ AliasListT = TypeAliasType("AliasListT", list[T], type_params=(T,))
 AliasFuncP = TypeAliasType("AliasFuncP", Callable[P, int], type_params=(P,))
 # Edge case: ``TypeAliasType`` used with a ``TypeVarTuple`` alias
 AliasTupleTs = TypeAliasType("AliasTupleTs", tuple[*Ts], type_params=(Ts,))
+# Edge case: ``TypeAliasType`` with constrained and bound type variables
+AliasNumberLikeList = TypeAliasType("AliasNumberLikeList", list[NumberLike], type_params=(NumberLike,))
+AliasBoundU = TypeAliasType("AliasBoundU", list[U], type_params=(U,))
 
 GLOBAL: int
 CONST: Final[str]

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -51,6 +51,10 @@ type AliasFuncP[**P] = Callable[P, int]
 
 type AliasTupleTs[*Ts] = tuple[Unpack[Ts]]
 
+type AliasNumberLikeList[NumberLike: (int, float)] = list[NumberLike]
+
+type AliasBoundU[U: str] = list[U]
+
 UNTYPED_LAMBDA: function
 
 TYPED_LAMBDA: Callable[[int, int], int]


### PR DESCRIPTION
## Summary
- format type parameters for `TypeAliasType`
- test TypeAliasType alias parameters with bounds and constraints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688096519c188329922bd50869c1b6c6