### PR TITLE
Add override decorator support

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -527,6 +527,9 @@ class PyiFunction(PyiNamedElement):
         if getattr(fn, "__final__", False):
             decorators.append("final")
             used_types.add(typing.final)
+        if getattr(fn, "__override__", False):
+            decorators.append("override")
+            used_types.add(getattr(typing, "override"))
         if "overload" in decorators:
             used_types.add(typing.overload)
 

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -36,6 +36,7 @@ from typing import (
     runtime_checkable,
     TypeGuard,
     final,
+    override,
 )
 
 T = TypeVar("T")
@@ -143,6 +144,13 @@ class Basic:
 
 class Child(Basic):
     ...
+
+
+# Edge case: ``@override`` decorator handling
+class OverrideChild(Basic):
+    @override
+    def copy(self, param: T) -> T:
+        return param
 
 
 class SampleDict(TypedDict):

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload, runtime_checkable
+from typing import Annotated, Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload, override, runtime_checkable
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from enum import Enum, IntEnum
@@ -95,6 +95,10 @@ class Basic:
 
 class Child(Basic):
     pass
+
+class OverrideChild(Basic):
+    @override
+    def copy[T](self, param: T) -> T: ...
 
 class SampleDict(TypedDict):
     name: str


### PR DESCRIPTION
## Summary
- support detecting `typing.override`
- add `OverrideChild` example with `@override`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688098bb38b883298bcd84d6724f3238