### PR TITLE
Handle forward reference type aliases

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -875,13 +875,19 @@ class PyiModule:
         handled_names: set[str] = set()
         for name, obj in globals_dict.items():
             if resolved_ann.get(name) is typing.TypeAlias:
-                fmt = format_type(obj)
-                used_types.update(fmt.used)
+                if isinstance(obj, str):
+                    fmt_text = obj
+                    alias_used: set[type] = set()
+                else:
+                    fmt = format_type(obj)
+                    fmt_text = fmt.text
+                    alias_used = fmt.used
+                    used_types.update(alias_used)
                 body.append(
                     PyiAlias(
                         name=name,
-                        value=fmt.text,
-                        used_types=fmt.used,
+                        value=fmt_text,
+                        used_types=alias_used,
                     )
                 )
                 continue

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -67,6 +67,9 @@ type IntFunc[**P] = Callable[P, int]
 type LabeledTuple[*Ts] = tuple[str, *Ts]
 type RecursiveList[T] = T | list[RecursiveList[T]]
 
+# Edge case: alias referencing a forward-declared class
+ForwardAlias: TypeAlias = "FutureClass"
+
 # Edge case: alias defined via ``TypeAliasType`` for a TypeVar alias
 AliasListT = TypeAliasType("AliasListT", list[T], type_params=(T,))
 # Edge case: ``TypeAliasType`` used with a ``ParamSpec`` alias
@@ -444,3 +447,7 @@ def cached_add(a: int, b: int) -> int:
 # Edge case: ``Annotated`` parameter and return types
 def annotated_fn(x: Annotated[int, "inp"]) -> Annotated[str, "out"]:
     return str(x)
+
+
+class FutureClass:
+    ...

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -45,6 +45,8 @@ type LabeledTuple[*Ts] = tuple[str, Unpack[Ts]]
 
 type RecursiveList[T] = T | list[RecursiveList[T]]
 
+ForwardAlias = FutureClass
+
 type AliasListT[T] = list[T]
 
 type AliasFuncP[**P] = Callable[P, int]
@@ -277,6 +279,9 @@ def iter_sequence(seq: Sequence[int]) -> Iterator[int]: ...
 def cached_add(a: int, b: int) -> int: ...
 
 def annotated_fn(x: Annotated[int, 'inp']) -> Annotated[str, 'out']: ...
+
+class FutureClass:
+    pass
 
 GLOBAL: int
 


### PR DESCRIPTION
## Summary
- support `TypeAlias` that references a class defined later
- test forward-reference alias generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68809cc598dc8329a166aaa2cc188739