### PR TITLE
Add async generator test case

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -408,6 +408,11 @@ NONE_VAR: None = None
 async def async_add_one(x: int) -> int:
     return x + 1
 
+# Edge case: async generator function
+async def gen_range(n: int) -> cabc.AsyncIterator[int]:
+    for i in range(n):
+        yield i
+
 # Edge case: ``final`` decorator handling
 @final
 def final_func(x: int) -> int:

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,5 +1,5 @@
 from typing import Annotated, Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload, override, runtime_checkable
-from collections.abc import Iterator, Sequence
+from collections.abc import AsyncIterator, Iterator, Sequence
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from functools import cached_property
@@ -256,6 +256,8 @@ def echo_literal(value: LiteralString) -> LiteralString: ...
 NONE_VAR: None
 
 async def async_add_one(x: int) -> int: ...
+
+async def gen_range(n: int) -> AsyncIterator[int]: ...
 
 @final
 def final_func(x: int) -> int: ...


### PR DESCRIPTION
## Summary
- extend annotations test module with an async generator function
- update expected stub to include the new function and AsyncIterator import

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68809fb2f6748329941bee183a3b5827