### PR TITLE
Improve TYPE_CHECKING handling

### DIFF
--- a/tests/circ_expr_a.py
+++ b/tests/circ_expr_a.py
@@ -1,0 +1,13 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING or False:
+    from tests.circ_expr_b import BComplex
+else:
+    BComplex = int
+
+class AComplex:
+    pass
+
+def takes_b(x: 'BComplex') -> None:
+    pass
+

--- a/tests/circ_expr_a.pyi
+++ b/tests/circ_expr_a.pyi
@@ -1,0 +1,6 @@
+from tests.circ_expr_b import BComplex
+
+class AComplex:
+    pass
+
+def takes_b(x: BComplex) -> None: ...

--- a/tests/circ_expr_b.py
+++ b/tests/circ_expr_b.py
@@ -1,0 +1,13 @@
+from typing import TYPE_CHECKING
+
+if False or TYPE_CHECKING:
+    from tests.circ_expr_a import AComplex
+else:
+    AComplex = int
+
+class BComplex:
+    pass
+
+def takes_a(x: 'AComplex') -> None:
+    pass
+

--- a/tests/circ_expr_b.pyi
+++ b/tests/circ_expr_b.pyi
@@ -1,0 +1,6 @@
+from tests.circ_expr_a import AComplex
+
+class BComplex:
+    pass
+
+def takes_a(x: AComplex) -> None: ...

--- a/tests/test_type_checking.py
+++ b/tests/test_type_checking.py
@@ -18,3 +18,20 @@ def test_circular_type_checking_imports():
     lines = stub_lines(mod_a)
     expected = base.with_name("circ_a.pyi").read_text().splitlines()
     assert lines == expected
+
+def test_circular_complex_expr_imports():
+    base = Path(__file__)
+    mod_b = load_module_from_path(
+        base.with_name("circ_expr_b.py"),
+        type_checking=True,
+        module_name="tests.circ_expr_b",
+    )
+    mod_a = load_module_from_path(
+        base.with_name("circ_expr_a.py"),
+        type_checking=True,
+        module_name="tests.circ_expr_a",
+    )
+
+    lines = stub_lines(mod_a)
+    expected = base.with_name("circ_expr_a.pyi").read_text().splitlines()
+    assert lines == expected


### PR DESCRIPTION
## Summary
- handle boolean expressions containing `TYPE_CHECKING`
- test circular imports guarded by complex expressions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880c1a4cae88329aa06a8ef2546b44c