### PR TITLE
Handle unannotated constants

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -91,6 +91,9 @@ FUNC_ELLIPSIS: Callable[..., int]
 # Variable using tuple ellipsis syntax
 TUPLE_VAR: tuple[int, ...]
 
+# Edge case: unannotated constant should be included
+UNANNOTATED_CONST = 42
+
 # Edge case: lambda expressions should be treated as variables, not functions
 UNTYPED_LAMBDA = lambda x, y: x + y
 TYPED_LAMBDA: Callable[[int, int], int] = lambda a, b: a + b

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -57,6 +57,8 @@ type AliasNumberLikeList[NumberLike: (int, float)] = list[NumberLike]
 
 type AliasBoundU[U: str] = list[U]
 
+UNANNOTATED_CONST: int
+
 UNTYPED_LAMBDA: function
 
 TYPED_LAMBDA: Callable[[int, int], int]


### PR DESCRIPTION
## Summary
- include unannotated constants in generated stubs
- ignore module dunder and `TYPE_CHECKING` variables
- test unannotated constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d027fc648329b8b798d4d8f6d505