### PR TITLE
Handle alias to foreign object

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -1203,6 +1203,14 @@ class _ModuleBuilder:
                 self._add(
                     PyiVariable(name=name, type_str=fmt.text, used_types=fmt.used)
                 )
+            elif isinstance(obj, (int, str, float, bool)):
+                self._add(PyiVariable.from_assignment(name, obj))
+            else:
+                alias_name = getattr(obj, "__name__", None)
+                if alias_name and alias_name != name:
+                    self._add(
+                        PyiAlias(name=name, value=alias_name, used_types={obj})
+                    )
             self.handled_names.add(name)
             return True
         return False

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -1,6 +1,7 @@
 import re
 import sys
 import functools
+import math
 from functools import cached_property
 from dataclasses import dataclass, InitVar
 from enum import Enum, IntEnum
@@ -419,6 +420,9 @@ def is_str_list(val: list[object]) -> TypeGuard[list[str]]:
 
 # Edge case: LiteralString handling
 LITERAL_STR_VAR: LiteralString
+
+# Edge case: alias to a foreign function should be preserved
+SIN_ALIAS = math.sin
 
 
 def echo_literal(value: LiteralString) -> LiteralString:

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -3,6 +3,7 @@ from collections.abc import AsyncIterator, Iterator, Sequence
 from dataclasses import dataclass
 from enum import Enum, IntEnum
 from functools import cached_property
+from math import sin
 from re import Pattern
 
 T = TypeVar('T')
@@ -262,6 +263,8 @@ def always_raises() -> NoReturn: ...
 def never_returns() -> Never: ...
 
 def is_str_list(val: list[object]) -> TypeGuard[list[str]]: ...
+
+SIN_ALIAS = sin
 
 def echo_literal(value: LiteralString) -> LiteralString: ...
 


### PR DESCRIPTION
## Summary
- add failing test for aliasing an external object
- handle aliasing a foreign object in stub generation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d489430c8329aca552b0636f23cd