### PR TITLE
Handle local function aliases

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -1320,6 +1320,10 @@ class _ModuleBuilder:
         if self._handle_foreign_variable(name, obj):
             return
         if id(obj) in self.seen:
+            orig = self.seen[id(obj)]
+            if orig != name:
+                self._add(PyiAlias(name=name, value=orig))
+                self.handled_names.add(name)
             return
         self.seen[id(obj)] = name
         self.handled_names.add(name)

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -425,6 +425,13 @@ LITERAL_STR_VAR: LiteralString
 SIN_ALIAS = math.sin
 
 
+def local_alias_target(x: int) -> int:
+    return x
+
+# Edge case: alias to a local function should be preserved
+LOCAL_ALIAS = local_alias_target
+
+
 def echo_literal(value: LiteralString) -> LiteralString:
     return value
 

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -266,6 +266,10 @@ def is_str_list(val: list[object]) -> TypeGuard[list[str]]: ...
 
 SIN_ALIAS = sin
 
+def local_alias_target(x: int) -> int: ...
+
+LOCAL_ALIAS = local_alias_target
+
 def echo_literal(value: LiteralString) -> LiteralString: ...
 
 NONE_VAR: None


### PR DESCRIPTION
## Summary
- preserve local function aliases in generated stubs
- test aliasing a local function in annotations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880e6b15b64832990b7e08bd0b81f98