### PR TITLE
Handle generic TypedDict classes

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -1064,6 +1064,11 @@ class PyiClass(PyiNamedElement):
                 fmt = format_type_param(tp)
                 type_params.append(fmt.text)
                 used_types.update(fmt.used)
+        elif is_typeddict and getattr(klass, "__parameters__", ()):
+            for tp in klass.__parameters__:
+                fmt = format_type_param(tp)
+                type_params.append(fmt.text)
+                used_types.update(fmt.used)
 
         members: list[PyiElement] = []
 

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -50,6 +50,7 @@ NumberLike = TypeVar("NumberLike", int, float)
 CovariantT = TypeVar("CovariantT", covariant=True)
 ContravariantT = TypeVar("ContravariantT", contravariant=True)
 InferredT = TypeVar("InferredT", infer_variance=True)
+TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
 
 MyList: TypeAlias = list[int]
@@ -180,6 +181,11 @@ class BaseTD(TypedDict):
 
 class SubTD(BaseTD):
     sub_field: str
+
+
+# Edge case: Generic TypedDict should retain type parameters
+class GenericBox(TypedDict, Generic[TDV]):
+    item: TDV
 
 
 class GenericClass(Generic[T]):

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -22,6 +22,8 @@ ContravariantT = TypeVar('ContravariantT', contravariant=True)
 
 InferredT = TypeVar('InferredT', infer_variance=True)
 
+TDV = TypeVar('TDV')
+
 UserId = NewType('UserId', int)
 
 MyList = list[int]
@@ -123,6 +125,9 @@ class BaseTD(TypedDict):
 
 class SubTD(BaseTD):
     sub_field: str
+
+class GenericBox[TDV](TypedDict):
+    item: TDV
 
 class GenericClass[T]:
     value: T


### PR DESCRIPTION
## Summary
- support extracting type parameters from generic TypedDict classes
- document GenericBox in annotations tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880ef1cd8dc8329ad27c5e50376d512