### PR TITLE
Handle annotated constants correctly

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -1202,15 +1202,14 @@ class _ModuleBuilder:
 
     def _handle_foreign_variable(self, name: str, obj: Any) -> bool:
         if not hasattr(obj, "__module__"):
-            if isinstance(obj, (int, str, float, bool)):
+            annotation = self.resolved_ann.get(name)
+            if annotation is not None:
+                fmt = format_type(annotation)
+                self._add(
+                    PyiVariable(name=name, type_str=fmt.text, used_types=fmt.used)
+                )
+            elif isinstance(obj, (int, str, float, bool)):
                 self._add(PyiVariable.from_assignment(name, obj))
-            else:
-                annotation = self.resolved_ann.get(name)
-                if annotation is not None:
-                    fmt = format_type(annotation)
-                    self._add(
-                        PyiVariable(name=name, type_str=fmt.text, used_types=fmt.used)
-                    )
             self.handled_names.add(name)
             return True
         if obj.__module__ != self.mod_name:

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -93,6 +93,10 @@ FUNC_ELLIPSIS: Callable[..., int]
 # Variable using tuple ellipsis syntax
 TUPLE_VAR: tuple[int, ...]
 
+# Edge case: annotated constants with values should honor the annotation
+ANNOTATED_FINAL: Final[int] = 5
+ANNOTATED_CLASSVAR: ClassVar[int] = 1
+
 # Edge case: unannotated constant should be included
 UNANNOTATED_CONST = 42
 

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -60,6 +60,10 @@ type AliasNumberLikeList[NumberLike: (int, float)] = list[NumberLike]
 
 type AliasBoundU[U: str] = list[U]
 
+ANNOTATED_FINAL: Final[int]
+
+ANNOTATED_CLASSVAR: ClassVar[int]
+
 UNANNOTATED_CONST: int
 
 UNTYPED_LAMBDA: function


### PR DESCRIPTION
## Summary
- fix constant handling so annotations aren't ignored for primitive values
- add test cases for annotated constants

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f819a478832989b2463a0086bdb7