### PR TITLE
Fix override decorator on descriptors

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -847,10 +847,9 @@ def _descriptor_members(
     for attr_type, (func_attr, deco) in _ATTR_DECORATORS.items():
         if isinstance(unwrapped, attr_type):
             fn_obj = getattr(unwrapped, func_attr)
-            if unwrapped is not attr:
-                for flag in ("__final__", "__override__"):
-                    if getattr(attr, flag, False) and not getattr(fn_obj, flag, False):
-                        setattr(fn_obj, flag, True)
+            for flag in ("__final__", "__override__"):
+                if getattr(attr, flag, False) and not getattr(fn_obj, flag, False):
+                    setattr(fn_obj, flag, True)
             func = PyiFunction.from_function(
                 fn_obj,
                 decorators=[deco],

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -157,6 +157,18 @@ class OverrideChild(Basic):
     def copy(self, param: T) -> T:
         return param
 
+# Edge case: @override applied after descriptor
+class OverrideLate(Basic):
+    @override
+    @classmethod
+    def cls_override(cls) -> int:
+        return 1
+
+    @override
+    @staticmethod
+    def static_override() -> int:
+        return 2
+
 
 class SampleDict(TypedDict):
     name: str

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -107,6 +107,14 @@ class OverrideChild(Basic):
     @override
     def copy[T](self, param: T) -> T: ...
 
+class OverrideLate(Basic):
+    @classmethod
+    @override
+    def cls_override(cls) -> int: ...
+    @staticmethod
+    @override
+    def static_override() -> int: ...
+
 class SampleDict(TypedDict):
     name: str
     age: int


### PR DESCRIPTION
## Summary
- fix override detection for descriptors like `classmethod` and `staticmethod`
- add tests for `@override` when applied after descriptors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880fd2e3f448329b984ea9fa474480e