### PR TITLE
Fix Final annotation on assigned constants

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -1200,20 +1200,18 @@ class _ModuleBuilder:
         return False
 
     def _handle_foreign_variable(self, name: str, obj: Any) -> bool:
+        annotation = self.resolved_ann.get(name)
         if not hasattr(obj, "__module__"):
-            if isinstance(obj, (int, str, float, bool)):
+            if annotation is not None:
+                fmt = format_type(annotation)
+                self._add(
+                    PyiVariable(name=name, type_str=fmt.text, used_types=fmt.used)
+                )
+            elif isinstance(obj, (int, str, float, bool)):
                 self._add(PyiVariable.from_assignment(name, obj))
-            else:
-                annotation = self.resolved_ann.get(name)
-                if annotation is not None:
-                    fmt = format_type(annotation)
-                    self._add(
-                        PyiVariable(name=name, type_str=fmt.text, used_types=fmt.used)
-                    )
             self.handled_names.add(name)
             return True
         if obj.__module__ != self.mod_name:
-            annotation = self.resolved_ann.get(name)
             if annotation is not None:
                 fmt = format_type(annotation)
                 self._add(

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -445,6 +445,10 @@ def is_str_list(val: list[object]) -> TypeGuard[list[str]]:
 # Edge case: LiteralString handling
 LITERAL_STR_VAR: LiteralString
 
+# Edge case: ``Final`` annotated variables with values
+FINAL_VAR_WITH_VALUE: Final[int] = 5
+PLAIN_FINAL_VAR: Final = 1
+
 # Edge case: alias to a foreign function should be preserved
 SIN_ALIAS = math.sin
 

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -282,6 +282,10 @@ def never_returns() -> Never: ...
 
 def is_str_list(val: list[object]) -> TypeGuard[list[str]]: ...
 
+FINAL_VAR_WITH_VALUE: Final[int]
+
+PLAIN_FINAL_VAR: Final
+
 SIN_ALIAS = sin
 
 def local_alias_target(x: int) -> int: ...


### PR DESCRIPTION
## Summary
- preserve `Final` annotations on assigned constants
- add regression tests for constants annotated with `Final`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68810129ed488329a9e97a96b2d12e27