### PR TITLE
Fix handling of type parameter defaults

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -232,7 +232,8 @@ def format_type_param(tp: Any) -> TypeRenderInfo:
 
     if hasattr(tp, "__default__"):
         default = getattr(tp, "__default__")
-        if default is not None and default is not typing.NoDefault:
+        _no_default = getattr(typing, "NoDefault", None)
+        if default is not None and (_no_default is None or default is not _no_default):
             if isinstance(default, tuple) and all(isinstance(d, type) for d in default):
                 parts = [format_type(d) for d in default]
                 used.update(*(p.used for p in parts))

--- a/tests/annotations_13.py
+++ b/tests/annotations_13.py
@@ -16,3 +16,10 @@ def overly_generic[
     *e: SimpleTypeVarTuple,
 ) -> None:
     ...
+
+# Edge case: alias with a default type parameter
+type DefaultList[T = int] = list[T]
+
+# Edge case: class with a default type parameter
+class DefaultBox[T = int]:
+    value: T

--- a/tests/annotations_13.pyi
+++ b/tests/annotations_13.pyi
@@ -1,3 +1,8 @@
 from typing import Callable
 
 def overly_generic[SimpleTypeVar, TypeVarWithBound: int, TypeVarWithConstraints: (str, bytes), TypeVarWithDefault = int, *SimpleTypeVarTuple = (int, float), **SimpleParamSpec = (str, bytearray)](a: SimpleTypeVar, b: TypeVarWithDefault, c: TypeVarWithBound, d: Callable[SimpleParamSpec, TypeVarWithConstraints], *e: SimpleTypeVarTuple) -> None: ...
+
+type DefaultList[T = int] = list[T]
+
+class DefaultBox[T = int]:
+    value: T


### PR DESCRIPTION
## Summary
- support `__default__` on type parameters when `typing.NoDefault` is missing
- add coverage for default type parameters in annotations_13

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688104ea9d108329a281332bb27053fd