### PR TITLE
Support emit_as with overloads

### DIFF
--- a/macrotype/__init__.py
+++ b/macrotype/__init__.py
@@ -1,5 +1,8 @@
 """Utilities for extracting type information and generating stub files."""
 
+import sys
+import typing
+
 from .pyi_extract import (
     PyiElement,
     TypeRenderInfo,
@@ -31,6 +34,9 @@ from .stubgen import (
     process_directory,
 )
 
+from .overload_support import _OVERLOAD_REGISTRY
+from typing import Literal
+
 __all__ += [
     "load_module_from_path",
     "load_module_from_code",
@@ -40,14 +46,67 @@ __all__ += [
     "process_file",
     "process_directory",
     "emit_as",
+    "make_literal_map",
 ]
 
 
 def emit_as(name: str):
-    """Decorator that overrides the emitted name for a function or class."""
+    """Decorator that overrides the emitted name for a function or class.
+
+    When ``@overload`` definitions are executed inside the decorated object,
+    they register themselves under the original qualified name.  This helper
+    moves those registrations so that lookups by the emitted name succeed.
+    """
 
     def set_qualname(obj):
         obj.__qualname_override__ = name
+
+        mod_overloads = _OVERLOAD_REGISTRY.get(obj.__module__)
+        if mod_overloads:
+            old_prefix = obj.__qualname__ + "."
+            new_prefix = name + "."
+            for key in list(mod_overloads.keys()):
+                if key.startswith(old_prefix):
+                    funcs = mod_overloads.pop(key)
+                    new_key = new_prefix + key[len(old_prefix):]
+                    mod_overloads[new_key] = funcs
+                    method_name = key[len(old_prefix):].split(".", 1)[0]
+                    attr = getattr(obj, method_name, None)
+                    if callable(attr):
+                        setattr(attr, "__overload_name__", new_key)
+                    for ov in funcs:
+                        setattr(ov, "__overload_name__", new_key)
+
         return obj
 
     return set_qualname
+
+
+def make_literal_map(name: str, mapping: dict[str | int, str | int]):
+    """Dynamically build a class exposing ``mapping`` via ``Literal`` overloads."""
+
+    caller_mod = sys._getframe(1).f_globals.get("__name__", "__main__")
+
+    @emit_as(name)
+    class LiteralMap:
+        for k, v in mapping.items():
+            @typing.overload  # type: ignore[misc]
+            def __getitem__(self, key: Literal[k]) -> Literal[v]: ...
+
+        def __getitem__(self, key):
+            return mapping[key]
+
+    old_mod = LiteralMap.__module__
+    LiteralMap.__module__ = caller_mod
+    for attr_name, attr in list(LiteralMap.__dict__.items()):
+        if callable(attr):
+            attr.__module__ = caller_mod
+
+    if old_mod != caller_mod:
+        old_overloads = _OVERLOAD_REGISTRY.get(old_mod)
+        if old_overloads:
+            for key in list(old_overloads.keys()):
+                if key.startswith(name + "."):
+                    _OVERLOAD_REGISTRY[caller_mod][key] = old_overloads.pop(key)
+
+    return LiteralMap

--- a/macrotype/overload_support.py
+++ b/macrotype/overload_support.py
@@ -23,7 +23,8 @@ def overload(func: Callable) -> Callable:
 def get_overloads(func: Callable) -> list[Callable]:
     """Return overloads registered for *func* including builtin ones."""
     f = getattr(func, "__func__", func)
-    ours = _OVERLOAD_REGISTRY[f.__module__][f.__qualname__]
+    qualname = getattr(f, "__overload_name__", getattr(f, "__qualname_override__", f.__qualname__))
+    ours = _OVERLOAD_REGISTRY[f.__module__][qualname]
     return _ORIG_GET_OVERLOADS(f) + list(ours)
 
 

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -39,7 +39,7 @@ from typing import (
     final,
     override,
 )
-from macrotype import emit_as
+from macrotype import emit_as, make_literal_map
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -623,3 +623,7 @@ def make_emitter_cls(name: str):
 
 
 EmittedCls = make_emitter_cls("EmittedCls")
+
+
+# Use emit_as with overloads defined dynamically on a class via API helper
+EmittedMap = make_literal_map("EmittedMap", {"a": 1, "b": 2})

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -363,6 +363,13 @@ def make_emitter_cls(name: str): ...
 class EmittedCls:
     value: int
 
+class EmittedMap:
+    @overload
+    def __getitem__(self, key: Literal['a']) -> Literal[1]: ...
+    @overload
+    def __getitem__(self, key: Literal['b']) -> Literal[2]: ...
+    def __getitem__(self, key: Any): ...
+
 GLOBAL: int
 
 CONST: Final[str]


### PR DESCRIPTION
## Summary
- update `emit_as` to rename overload registry entries when applying an alias
- teach `get_overloads` to use a stored overload name
- add `make_literal_map` helper for dynamic classes using `Literal` overloads
- test `emit_as` combined with overloads via the new helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881517d34c883298773fe07a5b9c458