### PR TITLE
Forward overload registry to typing

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -44,6 +44,7 @@ from macrotype.meta_types import (
     make_literal_map,
     set_module,
     get_caller_module,
+    overload,
 )
 
 T = TypeVar("T")

--- a/tests/test_meta_types.py
+++ b/tests/test_meta_types.py
@@ -1,0 +1,16 @@
+import typing
+
+from macrotype.meta_types import patch_typing, overload, get_overloads, clear_registry
+
+def test_patch_typing_updates_typing_registry():
+    with patch_typing():
+        @overload
+        def local(x: int) -> int: ...
+        def local(x: int) -> int:
+            return x
+
+    assert typing.get_overloads(local) == get_overloads(local)
+
+    clear_registry()
+    assert typing.get_overloads(local) == []
+    assert get_overloads(local) == []


### PR DESCRIPTION
## Summary
- keep typing's overload list updated when using macrotype's overload helper
- clear typing's registry when `clear_registry()` is called
- exercise `overload` passthrough using dedicated tests
- remove pointless overload test from annotations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887b30153ac8329ab4cb02b560fb647