### PR TITLE
Separate ruff lint from tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,26 @@
-name: Test
+name: CI
 
 on:
   push:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+      - name: Ruff formatting and linting
+        run: |
+          ruff format --check .
+          ruff check .
+
   pytest:
     runs-on: ubuntu-latest
     steps:
@@ -16,10 +32,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[test]' pytest
-      - name: Ruff formatting and linting
-        run: |
-          ruff format --check .
-          ruff check .
       - name: Run tests
         run: |
           pytest -q


### PR DESCRIPTION
## Summary
- split the CI workflow into two independent jobs
  - `lint` runs ruff formatting and linting
  - `pytest` runs unit tests
- ensure tests still run even when lint fails

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68883c2192908329b3c692b54b3d1031