### PR TITLE
Add stub verification to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,24 @@ jobs:
           ruff format --check .
           ruff check .
 
+  stubs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install macrotype
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+      - name: Regenerate stubs
+        run: |
+          python -m macrotype macrotype
+      - name: Ensure stubs are up to date
+        run: |
+          git diff --exit-code macrotype/*.pyi
+
   pytest:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -48,3 +48,15 @@ In addition to the CLI tool, there are also helpers for generating
 dynamic types.  See `macrotype.meta_types`.  These are intended
 for you to import to enable dynamic programming patterns which
 would be unthinkable without `macrotype`.
+
+## Dogfooding
+
+The `macrotype` project uses the CLI on itself.  Running
+
+```bash
+python -m macrotype macrotype
+```
+
+regenerates the stub files for the package in place.  A CI job ensures that
+the checked in `.pyi` files are always in sync with the result of this
+command.

--- a/macrotype/__init__.pyi
+++ b/macrotype/__init__.pyi
@@ -1,0 +1,2 @@
+# Generated via: macrotype macrotype
+# Do not edit by hand

--- a/macrotype/__main__.pyi
+++ b/macrotype/__main__.pyi
@@ -1,0 +1,2 @@
+# Generated via: macrotype macrotype
+# Do not edit by hand

--- a/macrotype/cli.pyi
+++ b/macrotype/cli.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype macrotype -o stubs
+# Generated via: macrotype macrotype
 # Do not edit by hand
 def _stdout_write(lines: list[str], command: str | None) -> None: ...
 

--- a/macrotype/meta_types.pyi
+++ b/macrotype/meta_types.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype macrotype -o stubs
+# Generated via: macrotype macrotype
 # Do not edit by hand
 from typing import Any, Callable
 

--- a/macrotype/pyi_extract.pyi
+++ b/macrotype/pyi_extract.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype macrotype -o stubs
+# Generated via: macrotype macrotype
 # Do not edit by hand
 from typing import Any, Callable
 from dataclasses import _DataclassParams, dataclass

--- a/macrotype/stubgen.pyi
+++ b/macrotype/stubgen.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype macrotype -o stubs
+# Generated via: macrotype macrotype
 # Do not edit by hand
 from ast import If, NodeTransformer, expr, stmt
 from pathlib import Path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ exclude = [
     "tests/annotations_13.pyi",
     "tests/annotations.pyi",
     "tests/typechecking.pyi",
-    "stubs",
+    "macrotype/*.pyi",
 ]
 
 [tool.ruff.lint]

--- a/stubs/__init__.pyi
+++ b/stubs/__init__.pyi
@@ -1,2 +1,0 @@
-# Generated via: macrotype macrotype -o stubs
-# Do not edit by hand

--- a/stubs/__main__.pyi
+++ b/stubs/__main__.pyi
@@ -1,2 +1,0 @@
-# Generated via: macrotype macrotype -o stubs
-# Do not edit by hand

--- a/tests/test_dogfood.py
+++ b/tests/test_dogfood.py
@@ -5,7 +5,7 @@ from pathlib import Path
 # Ensure package root on path when running tests directly
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-STUBS_DIR = Path(__file__).resolve().parents[1] / "stubs"
+STUBS_DIR = Path(__file__).resolve().parents[1] / "macrotype"
 
 
 def test_cli_self(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- document dogfooding of Macrotype
- verify bundled stubs in CI

## Testing
- `ruff format --check .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68883da345548329a4fbe92071e8e494