### PR TITLE
Move supported PEP 695 examples into main annotations tests

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -73,6 +73,18 @@ MyList: TypeAlias = list[int]
 # Edge case: alias referencing a forward-declared class
 ForwardAlias: TypeAlias = "FutureClass"
 
+# PEP 695 ``type`` statements
+type StrList = list[str]
+type Alias0[T] = list[T]
+type Alias1[T] = Alias0[T]
+type AliasNewType = UserId
+type AliasTypeVar[T] = T
+type AliasUnion = int | str
+type ListOrSet[T] = list[T] | set[T]
+type IntFunc[**P] = Callable[P, int]
+type LabeledTuple[*Ts] = tuple[str, *Ts]
+type RecursiveList[T] = T | list[RecursiveList[T]]
+
 GLOBAL: int
 CONST: Final[str]
 # Variable typed ``Any`` to ensure explicit Any is preserved
@@ -312,6 +324,22 @@ class OldGeneric(Generic[T]):
 
     def get(self) -> T:
         return self.value
+
+
+# PEP 695 generic class syntax
+class NewGeneric[T]:
+    value: T
+
+    def get(self) -> T:
+        return self.value
+
+
+class BoundClass[T: int]:
+    value: T
+
+
+class ConstrainedClass[T: (int, str)]:
+    value: T
 
 
 class Color(Enum):

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -41,6 +41,26 @@ MyList = list[int]
 
 ForwardAlias = FutureClass
 
+type StrList = list[str]
+
+type Alias0[T] = list[T]
+
+type Alias1[T] = Alias0[T]
+
+type AliasNewType = UserId
+
+type AliasTypeVar[T] = T
+
+type AliasUnion = int | str
+
+type ListOrSet[T] = list[T] | set[T]
+
+type IntFunc[**P] = Callable[P, int]
+
+type LabeledTuple[*Ts] = tuple[str, Unpack[Ts]]
+
+type RecursiveList[T] = T | list[RecursiveList[T]]
+
 ANNOTATED_FINAL: Final[int]
 
 ANNOTATED_CLASSVAR: int
@@ -197,6 +217,16 @@ class ClassVarExample:
 class OldGeneric[T]:
     value: T
     def get(self) -> T: ...
+
+class NewGeneric[T]:
+    value: T
+    def get(self) -> T: ...
+
+class BoundClass[T: int]:
+    value: T
+
+class ConstrainedClass[T: (int, str)]:
+    value: T
 
 class Color(Enum):
     RED = 1

--- a/tests/annotations_unsupported.py
+++ b/tests/annotations_unsupported.py
@@ -1,14 +1,7 @@
 # These annotations use syntax standardized in PEP 695 but unsupported by mypy.
 # Each example below includes a comment describing the unsupported feature.
 
-from typing import (
-    Callable,
-    NewType,
-    ParamSpec,
-    TypeAlias,
-    TypeVar,
-    TypeVarTuple,
-)
+from typing import NewType, ParamSpec, TypeVar, TypeVarTuple
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -17,58 +10,6 @@ U = TypeVar("U")
 NumberLike = TypeVar("NumberLike")
 UserId = NewType("UserId", int)
 
-# PEP 695 type alias syntax is not yet recognized by mypy.
-MyList: TypeAlias = list[int]
-# Uses "type" statement for an alias
-# (mypy fails to parse `type` statement)
-type StrList = list[str]
-
-# Chain of generic type aliases using PEP 695 syntax
-# mypy cannot parse generic aliases defined with `type`.
-type Alias0[T] = list[T]
-# Alias referencing another generic alias
-# still unsupported due to PEP 695 syntax
-type Alias1[T] = Alias0[T]
-
-# Additional alias shapes demonstrating various type parameters
-# All still rely on PEP 695 syntax which mypy rejects.
-type AliasNewType = UserId
-# Simple TypeVar alias
-# unsupported due to PEP 695
-type AliasTypeVar[T] = T
-# Union alias
-# uses `type` syntax unsupported by mypy
-type AliasUnion = int | str
-# Alias with generic union
-# PEP 695 syntax unsupported
-type ListOrSet[T] = list[T] | set[T]
-# Alias using ParamSpec
-# Not supported because mypy can't parse PEP 695 aliases with **P
-type IntFunc[**P] = Callable[P, int]
-# Alias with TypeVarTuple
-# mypy doesn't understand star-unpack in PEP 695 aliases yet
-type LabeledTuple[*Ts] = tuple[str, *Ts]
-# Recursive alias
-# mypy can't handle recursive aliases with PEP 695 syntax
-type RecursiveList[T] = T | list[RecursiveList[T]]
-
-
-# PEP 695 generic class syntax is entirely unsupported by mypy.
-class NewGeneric[T]:
-    value: T
-
-    def get(self) -> T:
-        return self.value
-
-
-# Class with explicit bound on type parameter
-class BoundClass[T: int]:
-    value: T
-
-
-# Class with constrained type parameter
-class ConstrainedClass[T: (int, str)]:
-    value: T
 
 
 # Function using ``P.args`` and ``P.kwargs`` requires PEP 695 generics

--- a/tests/annotations_unsupported.py
+++ b/tests/annotations_unsupported.py
@@ -11,7 +11,6 @@ NumberLike = TypeVar("NumberLike")
 UserId = NewType("UserId", int)
 
 
-
 # Function using ``P.args`` and ``P.kwargs`` requires PEP 695 generics
 # which mypy doesn't yet support.
 def use_params(*args: P.args, **kwargs: P.kwargs) -> int:

--- a/tests/annotations_unsupported.pyi
+++ b/tests/annotations_unsupported.pyi
@@ -1,13 +1,6 @@
 # Generated via: manual separation of unsupported features
 # These declarations use syntax from PEP 695 that mypy fails to parse.
-from typing import (
-    Callable,
-    NewType,
-    ParamSpec,
-    TypeVar,
-    TypeVarTuple,
-    Unpack,
-)
+from typing import NewType, ParamSpec, TypeVar, TypeVarTuple
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -15,38 +8,6 @@ Ts = TypeVarTuple("Ts")
 U = TypeVar("U")
 NumberLike = TypeVar("NumberLike")
 UserId = NewType("UserId", int)
-
-MyList = list[int]
-
-type StrList = list[str]
-
-type Alias0[T] = list[T]
-
-type Alias1[T] = Alias0[T]
-
-type AliasNewType = UserId
-
-type AliasTypeVar[T] = T
-
-type AliasUnion = int | str
-
-type ListOrSet[T] = list[T] | set[T]
-
-type IntFunc[**P] = Callable[P, int]
-
-type LabeledTuple[*Ts] = tuple[str, Unpack[Ts]]
-
-type RecursiveList[T] = T | list[RecursiveList[T]]
-
-class NewGeneric[T]:
-    value: T
-    def get(self) -> T: ...
-
-class BoundClass[T: int]:
-    value: T
-
-class ConstrainedClass[T: (int, str)]:
-    value: T
 
 def use_params(*args: P.args, **kwargs: P.kwargs) -> int: ...
 


### PR DESCRIPTION
## Summary
- move `type` aliases and generic classes out of `annotations_unsupported`
- keep only true mypy failures in the unsupported test files
- update `annotations.pyi` expectations

## Testing
- `ruff check`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ce06ddd88329a8fd8cb465ce4243