### PR TITLE
Preserve abstract methods in stubs

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Utilities for building ``.pyi`` objects from live Python modules."""
 
+import abc
 import dataclasses
 import enum
 import functools
@@ -588,6 +589,9 @@ def _collect_decorators(
     if getattr(fn, "__override__", False):
         decos.append("override")
         used.add(getattr(typing, "override"))
+    if getattr(fn, "__isabstractmethod__", False):
+        decos.append("abstractmethod")
+        used.add(abc.abstractmethod)
     if "overload" in decos:
         used.add(typing.overload)
     return decos, used
@@ -854,7 +858,7 @@ def _descriptor_members(
     for attr_type, (func_attr, deco) in _ATTR_DECORATORS.items():
         if isinstance(unwrapped, attr_type):
             fn_obj = getattr(unwrapped, func_attr)
-            for flag in ("__final__", "__override__"):
+            for flag in ("__final__", "__override__", "__isabstractmethod__"):
                 if getattr(attr, flag, False) and not getattr(fn_obj, flag, False):
                     setattr(fn_obj, flag, True)
             func = PyiFunction.from_function(

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -2,6 +2,7 @@ import collections.abc as cabc
 import functools
 import math
 import re
+from abc import ABC, abstractmethod
 from dataclasses import InitVar, dataclass
 from enum import Enum, IntEnum, IntFlag
 from functools import cached_property
@@ -662,3 +663,9 @@ def prepend_one(fn: Callable[Concatenate[int, P], int]) -> Callable[P, int]:
         return fn(1, *args, **kwargs)
 
     return inner
+
+
+# Class with an abstract method to verify abstract decorators
+class AbstractBase(ABC):
+    @abstractmethod
+    def do_something(self) -> int: ...

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,6 +1,7 @@
 # Generated via: macrotype tests/annotations.py -o -
 # Do not edit by hand
 from typing import Annotated, Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload, override, runtime_checkable
+from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator, Iterator, Sequence
 from dataclasses import InitVar, dataclass
 from enum import Enum, IntEnum, IntFlag
@@ -380,6 +381,10 @@ class Variadic[*Ts]:
     def to_tuple(self) -> tuple[Unpack[Ts]]: ...
 
 def prepend_one[**P](fn: Callable[Concatenate[int, P], int]) -> Callable[P, int]: ...
+
+class AbstractBase(ABC):
+    @abstractmethod
+    def do_something(self) -> int: ...
 
 GLOBAL: int
 


### PR DESCRIPTION
## Summary
- support `@abstractmethod` when generating stubs
- test abstract method handling in annotations module

## Testing
- `ruff format --check .`
- `ruff check .`
- `python -m macrotype macrotype`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68890f88dbfc83298f652dfa4b08e629