### PR TITLE
Remove redundant Final variable

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -436,8 +436,7 @@ def is_str_list(val: list[object]) -> TypeGuard[list[str]]:
 # Edge case: LiteralString handling
 LITERAL_STR_VAR: LiteralString
 
-# Edge case: ``Final`` annotated variables with values
-FINAL_VAR_WITH_VALUE: Final[int] = 5
+# Edge case: ``Final`` annotated variable with a value
 PLAIN_FINAL_VAR: Final[int] = 1
 
 # Edge case: alias to a foreign function should be preserved

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -278,8 +278,6 @@ def never_returns() -> Never: ...
 
 def is_str_list(val: list[object]) -> TypeGuard[list[str]]: ...
 
-FINAL_VAR_WITH_VALUE: Final[int]
-
 PLAIN_FINAL_VAR: Final[int]
 
 SIN_ALIAS = sin


### PR DESCRIPTION
## Summary
- drop duplicate `FINAL_VAR_WITH_VALUE` in annotations tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889298231888329a373c6452bd163d9