### PR TITLE
Remove redundant alias from tests

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -62,7 +62,6 @@ UserId = NewType("UserId", int)
 
 # Type aliases created via ``TypeAliasType``
 AliasListT = TypeAliasType("AliasListT", list[T], type_params=(T,))
-AliasFuncP = TypeAliasType("AliasFuncP", Callable[P, int], type_params=(P,))
 AliasTupleTs = TypeAliasType("AliasTupleTs", tuple[Unpack[Ts]], type_params=(Ts,))
 AliasNumberLikeList = TypeAliasType(
     "AliasNumberLikeList", list[NumberLike], type_params=(NumberLike,)

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -30,8 +30,6 @@ UserId = NewType('UserId', int)
 
 type AliasListT[T] = list[T]
 
-type AliasFuncP[**P] = Callable[P, int]
-
 type AliasTupleTs[*Ts] = tuple[Unpack[Ts]]
 
 type AliasNumberLikeList[NumberLike] = list[NumberLike]


### PR DESCRIPTION
## Summary
- drop `AliasFuncP` from annotations examples
- sync the pyi snapshot

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68892c68b87c83298159eafb7dbb2eee