### PR TITLE
Fix readthedocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,8 +1,11 @@
 version: 2
 sphinx:
   configuration: docs/conf.py
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
 python:
-  version: 3.12
   install:
     - method: pip
       path: .


### PR DESCRIPTION
## Summary
- ensure Read the Docs uses an explicit build

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897bf1d5b48329b7f8728917b34729