### PR TITLE
Fix README code block for Sphinx

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ Documentation
 -------------
 
 Full documentation is available on `Read the Docs <https://macrotype.readthedocs.io/>`_.
-To build the documentation locally, install the project with the ``doc`` optional
-dependency::
+To build the documentation locally, install the project with the ``doc`` optional dependency::
+
     pip install .[doc]
     sphinx-build docs docs/_build


### PR DESCRIPTION
## Summary
- fix README literal block causing Sphinx build error

## Testing
- `ruff format --check .`
- `ruff check .`
- `python -m macrotype macrotype`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68897fd958ec83299b155b1c1ffd1316