### PR TITLE
Add macrotype-check wrapper

### DIFF
--- a/__macrotype__/macrotype/typecheck.pyi
+++ b/__macrotype__/macrotype/typecheck.pyi
@@ -1,0 +1,7 @@
+# Generated via: macrotype macrotype
+# Do not edit by hand
+from pathlib import Path
+
+def _generate_stubs(paths: list[str], out_dir: Path, command: str) -> list[Path]: ...
+
+def main(argv: list[str] | None) -> int: ...

--- a/macrotype/typecheck.py
+++ b/macrotype/typecheck.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from . import stubgen
+from .cli import DEFAULT_OUT_DIR, _default_output_path
+
+
+def _generate_stubs(paths: list[str], out_dir: Path, command: str) -> list[Path]:
+    cwd = Path.cwd()
+    outputs: list[Path] = []
+    for target in paths:
+        path = Path(target)
+        default = _default_output_path(path, cwd, is_file=path.is_file())
+        rel = default.relative_to(DEFAULT_OUT_DIR)
+        dest = out_dir / rel
+        if path.is_file():
+            outputs.append(stubgen.process_file(path, dest, command=command))
+        else:
+            stubgen.process_directory(path, dest, command=command)
+            outputs.append(dest)
+    return outputs
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(argv or sys.argv[1:])
+    try:
+        dash = argv.index("--")
+    except ValueError:
+        dash = len(argv)
+    tool_args = argv[dash + 1 :]
+    argv = argv[:dash]
+
+    parser = argparse.ArgumentParser(prog="macrotype-check")
+    parser.add_argument("tool")
+    parser.add_argument("paths", nargs="+")
+    parser.add_argument("-o", "--output", default=str(DEFAULT_OUT_DIR))
+    args = parser.parse_args(argv)
+
+    command = "macrotype-check " + " ".join(argv + (["--"] + tool_args if tool_args else []))
+    out_dir = Path(args.output)
+    stub_paths = _generate_stubs(args.paths, out_dir, command)
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(out_dir) + os.pathsep + env.get("PYTHONPATH", "")
+    result = subprocess.run([args.tool, *map(str, stub_paths), *tool_args], env=env)
+    return result.returncode
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ where = ["."]
 
 [project.scripts]
 macrotype = "macrotype.cli:main"
+macrotype-check = "macrotype.typecheck:main"
 
 [project.optional-dependencies]
 test = ["mypy", "pyright", "ruff", "pytest"]

--- a/tests/test_typechecker_integration.py
+++ b/tests/test_typechecker_integration.py
@@ -1,0 +1,31 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize("tool", ["mypy", "pyright"])
+def test_macrotype_check(tmp_path: Path, tool: str) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    stub_dir = tmp_path / "stubs"
+    cmd = [
+        sys.executable,
+        "-m",
+        "macrotype.typecheck",
+        tool,
+        "tests/annotations.py",
+        "-o",
+        str(stub_dir),
+        "--",
+    ]
+    result = subprocess.run(
+        cmd,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        env=os.environ,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert (stub_dir / "tests" / "annotations.pyi").exists()


### PR DESCRIPTION
## Summary
- add new `macrotype.typecheck` CLI wrapper for type checkers
- wire `macrotype-check` entrypoint in `pyproject.toml`
- generate stubs for the new module
- test integration via mypy and pyright

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bc34db2b88329951020a62c1ea114