### PR TITLE
Fix README code highlighting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ How?
 
 ``macrotype`` is a CLI tool intended to be run before static type checking:
 
-.. code-block:: python
+.. code-block:: bash
 
     macrotype your_module
 
@@ -60,7 +60,7 @@ found.  The console script is installed as ``macrotype-check`` and accepts the
 checker command followed by the paths to stub.  Any additional arguments after
 ``--`` are passed through to the checker:
 
-.. code-block:: python
+.. code-block:: bash
 
     macrotype-check mypy src/ -- --strict
 
@@ -72,7 +72,7 @@ Dogfooding
 
 The ``macrotype`` project uses the CLI on itself.  Running:
 
-.. code-block:: python
+.. code-block:: bash
 
     python -m macrotype macrotype
 
@@ -85,7 +85,7 @@ Documentation
 Full documentation is available on `Read the Docs <https://macrotype.readthedocs.io/>`_.
 To build the documentation locally, install the project with the ``doc`` optional dependency:
 
-.. code-block:: python
+.. code-block:: bash
 
     pip install .[doc]
     sphinx-build docs docs/_build

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,9 @@
 Macrotype
 =========
 
-Consider this::
+Consider this:
+
+.. code-block:: python
 
     VAL = 42
 
@@ -18,7 +20,9 @@ checkers, so your types can be as dynamic as the rest of your Python code.
 How?
 -----
 
-``macrotype`` is a CLI tool intended to be run before static type checking::
+``macrotype`` is a CLI tool intended to be run before static type checking:
+
+.. code-block:: python
 
     macrotype your_module
 
@@ -26,7 +30,9 @@ How?
 corresponding ``.pyi`` files with all types pinned statically so the type
 checker can understand them.
 
-In our example, ``macrotype`` would generate this::
+In our example, ``macrotype`` would generate this:
+
+.. code-block:: python
 
     VAL: int
 
@@ -52,7 +58,9 @@ Most users will want to run their static type checker through the
 invokes your checker with ``PYTHONPATH`` configured so the generated stubs are
 found.  The console script is installed as ``macrotype-check`` and accepts the
 checker command followed by the paths to stub.  Any additional arguments after
-``--`` are passed through to the checker::
+``--`` are passed through to the checker:
+
+.. code-block:: python
 
     macrotype-check mypy src/ -- --strict
 
@@ -62,7 +70,9 @@ different directory.
 Dogfooding
 ----------
 
-The ``macrotype`` project uses the CLI on itself.  Running::
+The ``macrotype`` project uses the CLI on itself.  Running:
+
+.. code-block:: python
 
     python -m macrotype macrotype
 
@@ -73,7 +83,9 @@ Documentation
 -------------
 
 Full documentation is available on `Read the Docs <https://macrotype.readthedocs.io/>`_.
-To build the documentation locally, install the project with the ``doc`` optional dependency::
+To build the documentation locally, install the project with the ``doc`` optional dependency:
+
+.. code-block:: python
 
     pip install .[doc]
     sphinx-build docs docs/_build


### PR DESCRIPTION
## Summary
- use `.. code-block:: python` for README snippets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bfe22c8a88329abec7c234b0d996b