### PR TITLE
Add CallableNode to type_ast

### DIFF
--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -12,6 +12,7 @@ from macrotype.types_ast import (
     SetNode,
     TupleNode,
     UnionNode,
+    CallableNode,
     parse_type,
 )
 
@@ -53,6 +54,8 @@ PARSINGS = {
         AtomNode(str),
         UnionNode([AtomNode(int), AtomNode(type(None))]),
     ),
+    typing.Callable[[int, str], bool]: CallableNode([AtomNode(int), AtomNode(str)], AtomNode(bool)),
+    typing.Callable[..., int]: CallableNode(None, AtomNode(int)),
 }
 
 


### PR DESCRIPTION
## Summary
- support Callable types in `types_ast.parse_type`
- add tests for `CallableNode`

## Testing
- `ruff format --check macrotype/types_ast.py tests/types_ast_test.py` *(fails: ruff not installed)*
- `ruff check --fix macrotype/types_ast.py tests/types_ast_test.py` *(fails: ruff not installed)*
- `python -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_688c560f90c483299487cd33c6aa55e5