### PR TITLE
Add AnnotatedNode support

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -107,6 +107,9 @@ UNANNOTATED_CONST = 42
 UNTYPED_LAMBDA = lambda x, y: x + y
 TYPED_LAMBDA: Callable[[int, int], int] = lambda a, b: a + b
 
+# Additional variable using ``Annotated`` to test type parsing
+ANNOTATED_EXTRA: Annotated[str, "extra"] = "x"
+
 
 class Basic:
     simple: list[str]

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -71,6 +71,8 @@ UNTYPED_LAMBDA: function
 
 TYPED_LAMBDA: Callable[[int, int], int]
 
+ANNOTATED_EXTRA: Annotated[str, 'extra']
+
 class Basic:
     simple: list[str]
     mapping: dict[str, int]

--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -4,7 +4,9 @@ import typing
 import pytest
 
 from macrotype.types_ast import (
+    AnnotatedNode,
     AtomNode,
+    CallableNode,
     DictNode,
     FrozenSetNode,
     ListNode,
@@ -12,7 +14,6 @@ from macrotype.types_ast import (
     SetNode,
     TupleNode,
     UnionNode,
-    CallableNode,
     parse_type,
 )
 
@@ -56,6 +57,7 @@ PARSINGS = {
     ),
     typing.Callable[[int, str], bool]: CallableNode([AtomNode(int), AtomNode(str)], AtomNode(bool)),
     typing.Callable[..., int]: CallableNode(None, AtomNode(int)),
+    typing.Annotated[int, "x"]: AnnotatedNode(AtomNode(int), ["x"]),
 }
 
 


### PR DESCRIPTION
## Summary
- add AnnotatedNode to parse `typing.Annotated`
- test parsing for Annotated
- add annotated constant in annotation fixtures

## Testing
- `ruff format`
- `ruff check --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c5872a8b08329bb22c5f034384688