### PR TITLE
Refine UnpackNode typing

### DIFF
--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -13,6 +13,7 @@ from macrotype.types_ast import (
     LiteralNode,
     SetNode,
     TupleNode,
+    TypedDictNode,
     UnionNode,
     UnpackNode,
     parse_type,
@@ -64,7 +65,8 @@ PARSINGS = {
     typing.Callable[..., int]: CallableNode(None, AtomNode(int)),
     typing.Annotated[int, "x"]: AnnotatedNode(AtomNode(int), ["x"]),
     typing.Unpack[tuple[int, str]]: UnpackNode(TupleNode([AtomNode(int), AtomNode(str)])),
-    typing.Unpack[TD]: UnpackNode(AtomNode(TD)),
+    typing.Unpack[TD]: UnpackNode(TypedDictNode(TD)),
+    TD: TypedDictNode(TD),
 }
 
 


### PR DESCRIPTION
## Summary
- introduce `TypedDictNode` for TypedDict values
- restrict `UnpackNode` target to `TupleNode` or `TypedDictNode`
- update parsing logic and tests

## Testing
- `ruff format`
- `ruff check --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c96053ec08329bdecb6825c739534