### PR TITLE
Handle | unions in type parser

### DIFF
--- a/macrotype/types_ast.py
+++ b/macrotype/types_ast.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import collections.abc
 import dataclasses
 import enum
+import types
 import typing
 from dataclasses import dataclass
 from typing import (
@@ -318,6 +319,7 @@ def parse_type(typ: Any) -> BaseNode:
         typing.Annotated: AnnotatedNode,
         typing.Self: SelfNode,
         Union: UnionNode,
+        types.UnionType: UnionNode,
         typing.Unpack: UnpackNode,
     }
 

--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -62,6 +62,7 @@ PARSINGS = {
     set[int]: SetNode(AtomNode(int)),
     frozenset[str]: FrozenSetNode(AtomNode(str)),
     typing.Union[int, str]: UnionNode([AtomNode(int), AtomNode(str)]),
+    int | str: UnionNode([AtomNode(int), AtomNode(str)]),
     typing.Union[int, str, None]: UnionNode([AtomNode(int), AtomNode(str), AtomNode(type(None))]),
     dict[str, typing.Union[int, None]]: DictNode(
         AtomNode(str),


### PR DESCRIPTION
## Summary
- add support for `types.UnionType` in `parse_type`
- add a regression test for `int | str`

## Testing
- `ruff format macrotype/types_ast.py tests/types_ast_test.py`
- `ruff check macrotype/types_ast.py tests/types_ast_test.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cc64b2bb48329991cbfdaf1548402