### PR TITLE
Add AnnotatedNode tests

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -109,6 +109,8 @@ TYPED_LAMBDA: Callable[[int, int], int] = lambda a, b: a + b
 
 # Additional variable using ``Annotated`` to test type parsing
 ANNOTATED_EXTRA: Annotated[str, "extra"] = "x"
+# Nested Annotated usage should merge metadata
+NESTED_ANNOTATED: Annotated[Annotated[int, "a"], "b"] = 3
 
 
 class Basic:

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -73,6 +73,8 @@ TYPED_LAMBDA: Callable[[int, int], int]
 
 ANNOTATED_EXTRA: Annotated[str, 'extra']
 
+NESTED_ANNOTATED: Annotated[int, 'a', 'b']
+
 class Basic:
     simple: list[str]
     mapping: dict[str, int]

--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -137,3 +137,17 @@ def test_classvar_special_form() -> None:
 def test_final_special_form() -> None:
     with pytest.raises(TypeError):
         parse_type_expr(typing.Final[int])
+
+
+def test_annotated_nesting() -> None:
+    nested = typing.Annotated[typing.Annotated[int, "a"], "b"]
+    expected = AnnotatedNode(AtomNode(int), ["a", "b"])
+    assert parse_type(nested) == expected
+    assert parse_type_expr(nested) == expected
+
+
+def test_annotated_classvar() -> None:
+    ann = typing.Annotated[typing.ClassVar[int], "x"]
+    assert parse_type(ann) == AnnotatedNode(ClassVarNode(AtomNode(int)), ["x"])
+    with pytest.raises(TypeError):
+        parse_type_expr(ann)


### PR DESCRIPTION
## Summary
- add tests for AnnotatedNode handling including nested and ClassVar cases
- add nested Annotated usage in annotations test module

## Testing
- `ruff check --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd16a8b1c8329a01fe1c0cacd1544