### PR TITLE
Support TypeVars in type parser

### DIFF
--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -35,6 +35,12 @@ class TD(typing.TypedDict):
     value: int
 
 
+T = typing.TypeVar("T")
+P = typing.ParamSpec("P")
+Ts = typing.TypeVarTuple("Ts")
+AliasListT = typing.TypeAliasType("AliasListT", list[T], type_params=(T,))
+
+
 PARSINGS = {
     int: AtomNode(int),
     str: AtomNode(str),
@@ -84,6 +90,11 @@ PARSINGS = {
     typing.NoReturn: AtomNode(typing.NoReturn),
     typing.Never: AtomNode(typing.Never),
     typing.LiteralString: AtomNode(typing.LiteralString),
+    T: AtomNode(T),
+    P: AtomNode(P),
+    Ts: AtomNode(Ts),
+    typing.Unpack[Ts]: UnpackNode(AtomNode(Ts)),
+    AliasListT: ListNode(AtomNode(T)),
 }
 
 


### PR DESCRIPTION
## Summary
- add support for `TypeVar`, `ParamSpec`, `TypeVarTuple`, and `TypeAliasType` in `types_ast`
- allow `Unpack` of `TypeVarTuple`
- extend tests for these features

## Testing
- `ruff format tests/types_ast_test.py macrotype/types_ast.py`
- `ruff check --fix tests/types_ast_test.py macrotype/types_ast.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cd6f509008329bfcdc45889483880