### PR TITLE
Fix CallableNode handling in _reject_special

### DIFF
--- a/macrotype/types_ast.py
+++ b/macrotype/types_ast.py
@@ -459,8 +459,11 @@ def _reject_special(node: BaseNode) -> None:
             _reject_special(item)
     elif isinstance(node, CallableNode):
         if node.args is not None:
-            for arg in node.args:
-                _reject_special(arg)
+            if isinstance(node.args, list):
+                for arg in node.args:
+                    _reject_special(arg)
+            else:
+                _reject_special(node.args)
         _reject_special(node.return_type)
     elif isinstance(node, AnnotatedNode):
         _reject_special(node.base)


### PR DESCRIPTION
## Summary
- ensure _reject_special handles CallableNode.args when not a list

## Testing
- `ruff check --fix macrotype/types_ast.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf217d07c8329b5f02713b23b8504