### PR TITLE
Add NotRequired/Required parsing

### DIFF
--- a/macrotype/types_ast.py
+++ b/macrotype/types_ast.py
@@ -278,6 +278,38 @@ class FinalNode(Generic[N], ContainerNode[N], SpecialFormNode):
 
 
 @dataclass(frozen=True)
+class RequiredNode(Generic[N], ContainerNode[N], InClassExprNode):
+    """``typing.Required`` wrapper."""
+
+    inner: NodeLike[N]
+
+    def emit(self) -> TypeExpr:
+        return typing.Required[self.inner.emit()]
+
+    @classmethod
+    def for_args(cls, args: tuple[Any, ...]) -> "RequiredNode[N]":
+        if len(args) != 1:
+            raise TypeError(f"Required requires a single argument: {args}")
+        return cls(parse_type(args[0]))
+
+
+@dataclass(frozen=True)
+class NotRequiredNode(Generic[N], ContainerNode[N], InClassExprNode):
+    """``typing.NotRequired`` wrapper."""
+
+    inner: NodeLike[N]
+
+    def emit(self) -> TypeExpr:
+        return typing.NotRequired[self.inner.emit()]
+
+    @classmethod
+    def for_args(cls, args: tuple[Any, ...]) -> "NotRequiredNode[N]":
+        if len(args) != 1:
+            raise TypeError(f"NotRequired requires a single argument: {args}")
+        return cls(parse_type(args[0]))
+
+
+@dataclass(frozen=True)
 class TypeGuardNode(Generic[N], ContainerNode[N], SpecialFormNode):
     """``typing.TypeGuard`` wrapper."""
 
@@ -407,6 +439,8 @@ def parse_type(typ: Any) -> BaseNode:
         typing.Self: SelfNode,
         typing.ClassVar: ClassVarNode,
         typing.Final: FinalNode,
+        typing.Required: RequiredNode,
+        typing.NotRequired: NotRequiredNode,
         Union: UnionNode,
         types.UnionType: UnionNode,
         typing.Unpack: UnpackNode,

--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -16,6 +16,8 @@ from macrotype.types_ast import (
     InitVarNode,
     ListNode,
     LiteralNode,
+    NotRequiredNode,
+    RequiredNode,
     SelfNode,
     SetNode,
     TupleNode,
@@ -93,6 +95,8 @@ PARSINGS = {
     typing.Never: AtomNode(typing.Never),
     typing.LiteralString: AtomNode(typing.LiteralString),
     typing.TypeGuard[int]: TypeGuardNode(AtomNode(int)),
+    typing.NotRequired[int]: NotRequiredNode(AtomNode(int)),
+    typing.Required[str]: RequiredNode(AtomNode(str)),
     T: AtomNode(T),
     P: AtomNode(P),
     Ts: AtomNode(Ts),
@@ -176,3 +180,13 @@ def test_annotated_classvar() -> None:
     assert parse_type(ann) == AnnotatedNode(ClassVarNode(AtomNode(int)), ["x"])
     with pytest.raises(TypeError):
         parse_type_expr(ann)
+
+
+def test_notrequired_special_form() -> None:
+    with pytest.raises(TypeError):
+        parse_type_expr(typing.NotRequired[int])
+
+
+def test_required_special_form() -> None:
+    with pytest.raises(TypeError):
+        parse_type_expr(typing.Required[str])


### PR DESCRIPTION
## Summary
- support typing.Required and typing.NotRequired in types_ast
- test parsing roundtrip and special-form rejection

## Testing
- `ruff format macrotype/types_ast.py tests/types_ast_test.py`
- `ruff check --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf468f9f48329a666b172dd94c700