### PR TITLE
Handle Required/NotRequired in _reject_special

### DIFF
--- a/macrotype/types_ast.py
+++ b/macrotype/types_ast.py
@@ -517,3 +517,5 @@ def _reject_special(node: BaseNode) -> None:
         _reject_special(node.inner)
     elif isinstance(node, FinalNode):
         _reject_special(node.inner)
+    elif isinstance(node, (RequiredNode, NotRequiredNode)):
+        _reject_special(node.inner)

--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -190,3 +190,10 @@ def test_notrequired_special_form() -> None:
 def test_required_special_form() -> None:
     with pytest.raises(TypeError):
         parse_type_expr(typing.Required[str])
+
+
+def test_nested_required_notrequired() -> None:
+    with pytest.raises(TypeError):
+        parse_type_expr(list[typing.NotRequired[int]])
+    with pytest.raises(TypeError):
+        parse_type_expr(list[typing.Required[int]])


### PR DESCRIPTION
## Summary
- handle RequiredNode and NotRequiredNode in `_reject_special`
- add regression tests for nested Required/NotRequired

## Testing
- `ruff check --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cfa95f7a48329903e12d23bab742c