### PR TITLE
Refactor base parsing to use types_ast

### DIFF
--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -775,18 +775,32 @@ def _namedtuple_bases(klass: type, type_params: list[str]) -> tuple[list[str], s
         if get_origin(b) is typing.Generic:
             if not type_params:
                 for param in get_args(b):
-                    inner = param
-                    if get_origin(param) is typing.Unpack:
-                        inner = get_args(param)[0]
-                    if isinstance(
-                        inner,
+                    try:
+                        node = parse_type(param)
+                    except Exception:
+                        node = None
+                    if isinstance(node, UnpackNode):
+                        target = node.target
+                        if isinstance(target, AtomNode) and isinstance(
+                            target.type_,
+                            (
+                                typing.TypeVar,
+                                typing.ParamSpec,
+                                typing.TypeVarTuple,
+                            ),
+                        ):
+                            fmt = format_type_param(target.type_)
+                        else:
+                            fmt = format_type(param)
+                    elif isinstance(
+                        param,
                         (
                             typing.TypeVar,
                             typing.ParamSpec,
                             typing.TypeVarTuple,
                         ),
                     ):
-                        fmt = format_type_param(inner)
+                        fmt = format_type_param(param)
                     else:
                         fmt = format_type(param)
                     type_params.append(fmt.text)
@@ -821,18 +835,32 @@ def _normal_class_bases(klass: type, type_params: list[str]) -> tuple[list[str],
         if get_origin(b) is typing.Generic:
             if not type_params:
                 for param in get_args(b):
-                    inner = param
-                    if get_origin(param) is typing.Unpack:
-                        inner = get_args(param)[0]
-                    if isinstance(
-                        inner,
+                    try:
+                        node = parse_type(param)
+                    except Exception:
+                        node = None
+                    if isinstance(node, UnpackNode):
+                        target = node.target
+                        if isinstance(target, AtomNode) and isinstance(
+                            target.type_,
+                            (
+                                typing.TypeVar,
+                                typing.ParamSpec,
+                                typing.TypeVarTuple,
+                            ),
+                        ):
+                            fmt = format_type_param(target.type_)
+                        else:
+                            fmt = format_type(param)
+                    elif isinstance(
+                        param,
                         (
                             typing.TypeVar,
                             typing.ParamSpec,
                             typing.TypeVarTuple,
                         ),
                     ):
-                        fmt = format_type_param(inner)
+                        fmt = format_type_param(param)
                     else:
                         fmt = format_type(param)
                     type_params.append(fmt.text)

--- a/macrotype/types_ast.py
+++ b/macrotype/types_ast.py
@@ -189,8 +189,8 @@ class TupleNode(Generic[*Ctx], ContainerNode[typing.Union[*Ctx]]):
                 raise TypeError(
                     "tuple[T, ...] must have one or more arguments with Ellipsis in final position"
                 )
-            return cls(items=[parse_type(arg) for arg in args[:-1]], variable=True)
-        return cls(items=[parse_type(arg) for arg in args], variable=False)
+            return cls(items=tuple(parse_type(arg) for arg in args[:-1]), variable=True)
+        return cls(items=tuple(parse_type(arg) for arg in args), variable=False)
 
 
 @dataclass(frozen=True)

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -370,6 +370,11 @@ class NamedPoint(NamedTuple):
     y: int
 
 
+# NamedTuple with variadic type parameters to test Generic parsing
+class VarNamedTuple(NamedTuple, Generic[*Ts]):
+    items: tuple[Unpack[Ts]]
+
+
 def use_tuple(tp: tuple[int, ...]) -> tuple[int, ...]:
     return tp
 

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -247,6 +247,9 @@ class NamedPoint(NamedTuple):
     x: int
     y: int
 
+class VarNamedTuple[*Ts](NamedTuple):
+    items: tuple[Unpack[Ts]]
+
 def use_tuple(tp: tuple[int, ...]) -> tuple[int, ...]: ...
 
 class SelfExample:


### PR DESCRIPTION
## Summary
- use types_ast for Generic parameter inspection in pyi_extract
- preserve tuple containers in TupleNode
- add VarNamedTuple test covering Generic parsing

## Testing
- `ruff format tests/annotations.py macrotype/pyi_extract.py macrotype/types_ast.py`
- `ruff check --fix tests/annotations.py macrotype/pyi_extract.py macrotype/types_ast.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d0bff521083298aff01372111d3f2