### PR TITLE
Add bool literal overload coverage

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -106,6 +106,10 @@ ANNOTATED_CLASSVAR: int = 1
 # Edge case: unannotated constant should be included
 UNANNOTATED_CONST = 42
 
+# Edge case: boolean constants should be retained
+BOOL_TRUE = True
+BOOL_FALSE = False
+
 # Edge case: lambda expressions should be treated as variables, not functions
 UNTYPED_LAMBDA = lambda x, y: x + y
 TYPED_LAMBDA: Callable[[int, int], int] = lambda a, b: a + b
@@ -711,6 +715,13 @@ def parse_int_or_none(val: str | None) -> int | None:
 @overload_for(3)
 def times_two(val: int, factor: int = 2) -> int:
     return val * factor
+
+
+# Edge case: overload_for should support boolean literals
+@overload_for(True)
+@overload_for(False)
+def bool_gate(flag: bool) -> int:
+    return 1 if flag else 0
 
 
 # Class with an abstract method to verify abstract decorators

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -67,6 +67,10 @@ ANNOTATED_CLASSVAR: int
 
 UNANNOTATED_CONST: int
 
+BOOL_TRUE: bool
+
+BOOL_FALSE: bool
+
 UNTYPED_LAMBDA: function
 
 TYPED_LAMBDA: Callable[[int, int], int]
@@ -405,6 +409,15 @@ def times_two(val: Literal[3], factor: Literal[2]) -> Literal[6]: ...
 
 @overload
 def times_two(val: int, factor: int) -> int: ...
+
+@overload
+def bool_gate(flag: Literal[True]) -> Literal[1]: ...
+
+@overload
+def bool_gate(flag: Literal[False]) -> Literal[0]: ...
+
+@overload
+def bool_gate(flag: bool) -> int: ...
 
 class AbstractBase(ABC):
     @abstractmethod


### PR DESCRIPTION
## Summary
- cover boolean constants and overload cases in annotations fixture

## Testing
- `ruff check --fix`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d47ccdca48329be1b0d58a1a517e0