### PR TITLE
feat: add watch mode

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,19 @@ checker command followed by the paths to stub.  Any additional arguments after
 Stubs are written to ``__macrotype__`` by default; use ``-o`` to choose a
 different directory.
 
+Watch mode
+----------
+
+Use ``--watch`` (or ``-w``) to regenerate stubs whenever the source files
+change.  The command is re-run in a fresh Python process each time:
+
+.. code-block:: bash
+
+    macrotype --watch your_module
+
+The same flag is available for ``macrotype-check`` to rerun the wrapped type
+checker as files change.
+
 Dogfooding
 ----------
 

--- a/macrotype/watch.py
+++ b/macrotype/watch.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+from threading import Event
+from typing import Iterable
+
+from . import stubgen
+
+
+def _snapshot(paths: Iterable[Path]) -> dict[Path, float]:
+    files: list[Path] = []
+    for p in paths:
+        files.extend(stubgen.iter_python_files(p))
+    return {f: f.stat().st_mtime for f in files if f.exists()}
+
+
+def watch_and_run(
+    paths: Iterable[str | Path],
+    cmd: list[str],
+    *,
+    interval: float = 0.5,
+    stop_event: Event | None = None,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> int:
+    """Run *cmd* and watch *paths* for changes.
+
+    When any ``.py`` file under ``paths`` changes, ``cmd`` is executed again.
+    If ``stop_event`` is provided, the loop terminates when the event is set.
+    """
+
+    path_objs = [Path(p) for p in paths]
+
+    def run() -> int:
+        return subprocess.run(cmd, check=False, cwd=cwd, env=env).returncode
+
+    code = run()
+    mtimes = _snapshot(path_objs)
+    print("Watching for changes. Press Ctrl+C to exit.")
+    try:
+        while True:
+            if stop_event and stop_event.is_set():
+                break
+            time.sleep(interval)
+            new = _snapshot(path_objs)
+            if new != mtimes:
+                mtimes = new
+                code = run()
+    except KeyboardInterrupt:
+        pass
+    return code
+
+
+__all__ = ["watch_and_run"]

--- a/tests/test_watch_mode.py
+++ b/tests/test_watch_mode.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+from macrotype.watch import watch_and_run
+
+
+def test_watch_and_run_regenerates(tmp_path: Path) -> None:
+    src = tmp_path / "m.py"
+    src.write_text("a=1\n")
+    dest = tmp_path / "out.pyi"
+    cmd = [
+        sys.executable,
+        "-m",
+        "macrotype",
+        str(src),
+        "-o",
+        str(dest),
+    ]
+    env = os.environ | {"PYTHONPATH": str(Path(__file__).resolve().parents[1])}
+    stop = threading.Event()
+    thread = threading.Thread(
+        target=watch_and_run,
+        args=([src], cmd),
+        kwargs={"interval": 0.1, "stop_event": stop, "cwd": tmp_path, "env": env},
+    )
+    thread.start()
+
+    for _ in range(50):
+        if dest.exists():
+            break
+        time.sleep(0.1)
+    assert dest.exists()
+    assert "a: int" in dest.read_text()
+
+    src.write_text("b=1\n")
+    old = dest.read_text()
+    for _ in range(50):
+        time.sleep(0.1)
+        if dest.read_text() != old:
+            break
+    assert "b: int" in dest.read_text()
+
+    stop.set()
+    thread.join(5)


### PR DESCRIPTION
## Summary
- add `--watch` mode to rebuild stubs on source file changes
- support watching in `macrotype-check`
- document watch usage and add regression test

## Testing
- `ruff check --fix tests/test_watch_mode.py macrotype/watch.py macrotype/cli.py macrotype/typecheck.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e13a09a748329b0a84b91e773d64c