### PR TITLE
Handle descriptor-based type metadata

### DIFF
--- a/macrotype/types_ast.py
+++ b/macrotype/types_ast.py
@@ -679,10 +679,15 @@ def _format_runtime_type(type_obj: Any) -> TypeRenderInfo:
             return TypeRenderInfo(origin_name, used)
 
     if hasattr(type_obj, "__args__"):
-        arg_strs = [format_type(a) for a in type_obj.__args__]
-        used.update(*(a.used for a in arg_strs))
-        args_str = ", ".join(a.text for a in arg_strs)
-        return TypeRenderInfo(f"{type_obj.__class__.__name__}[{args_str}]", used)
+        try:
+            arg_iter = list(type_obj.__args__)
+        except TypeError:
+            arg_iter = []
+        if arg_iter:
+            arg_strs = [format_type(a) for a in arg_iter]
+            used.update(*(a.used for a in arg_strs))
+            args_str = ", ".join(a.text for a in arg_strs)
+            return TypeRenderInfo(f"{type_obj.__class__.__name__}[{args_str}]", used)
 
     if isinstance(type_obj, type):
         used.add(type_obj)

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -728,3 +728,9 @@ def bool_gate(flag: bool) -> int:
 class AbstractBase(ABC):
     @abstractmethod
     def do_something(self) -> int: ...
+
+
+# Class with non-iterable __parameters__ to ensure graceful handling
+class BadParams:
+    __parameters__ = 1
+    value: int

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype tests/annotations.py -o -
+# Generated via: macrotype tests/annotations.py -o tests/annotations.pyi
 # Do not edit by hand
 # pyright: basic
 from typing import Annotated, Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload, override, runtime_checkable
@@ -422,6 +422,9 @@ def bool_gate(flag: bool) -> int: ...
 class AbstractBase(ABC):
     @abstractmethod
     def do_something(self) -> int: ...
+
+class BadParams:
+    value: int
 
 GLOBAL: int
 


### PR DESCRIPTION
## Summary
- avoid crashing on built-in callables lacking inspectable signatures
- tolerate descriptor-based __parameters__, __type_params__, and __args__
- cover non-iterable __parameters__ with tests

## Testing
- `ruff format macrotype/pyi_extract.py macrotype/types_ast.py tests/annotations.py`
- `ruff check --fix macrotype/pyi_extract.py macrotype/types_ast.py tests/annotations.py`
- `python -m macrotype tests/annotations.py -o tests/annotations.pyi`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e18426ff48329b444a28a4dfa309d