### PR TITLE
Add GenericNode and generic callback handling

### DIFF
--- a/__macrotype__/macrotype/types_ast.pyi
+++ b/__macrotype__/macrotype/types_ast.pyi
@@ -1,6 +1,6 @@
-# Generated via: macrotype macrotype
+# Generated via: macrotype macrotype -o /tmp/tmp_stub
 # Do not edit by hand
-from typing import Any, ClassVar, ParamSpec, TypeVar, TypeVarTuple, Unpack, _TypedDictMeta
+from typing import Any, Callable, ClassVar, ParamSpec, TypeVar, TypeVarTuple, Unpack, _TypedDictMeta
 from dataclasses import dataclass
 from enum import Enum
 
@@ -50,6 +50,12 @@ class VarNode(TypeExprNode):
 @dataclass(frozen=True)
 class TypedDictNode(AtomNode):
     type_: _TypedDictMeta
+
+@dataclass(frozen=True)
+class GenericNode(ContainerNode[TypeExprNode]):
+    origin: type[Any]
+    args: tuple[BaseNode, ...]
+    def emit(self) -> Any: ...
 
 @dataclass(frozen=True)
 class LiteralNode(TypeExprNode):
@@ -203,9 +209,11 @@ class UnpackNode(SpecialFormNode):
 
 def _parse_no_origin_type(typ: Any) -> BaseNode: ...
 
-def _parse_origin_type(origin: Any, args: tuple[Any, ...]) -> BaseNode: ...
+def _parse_origin_type(origin: Any, args: tuple[Any, ...], raw: Any) -> BaseNode: ...
 
-def parse_type(typ: Any) -> BaseNode: ...
+_on_generic_callback: Callable[[GenericNode], BaseNode] | None
+
+def parse_type(typ: Any, *, on_generic: Callable[[GenericNode], BaseNode] | None) -> BaseNode: ...
 
 def parse_type_expr(typ: Any) -> TypeExprNode: ...
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,5 +1,24 @@
 .. include:: ../README.rst
 
+Generic type handling
+---------------------
+
+``macrotype`` can parse generic classes that lack built‑in handlers.  In this
+case :func:`macrotype.types_ast.parse_type` produces a
+``GenericNode`` capturing the original class and its type arguments.  Libraries
+can customize the result by providing an ``on_generic`` callback::
+
+    from collections import deque
+    from typing import Deque
+    from macrotype.types_ast import GenericNode, ListNode, parse_type
+
+    def handle(node: GenericNode):
+        if node.origin is deque:
+            return ListNode(node.args[0])
+        return node
+
+    parse_type(Deque[int], on_generic=handle)
+
 Module Documentation
 --------------------
 

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -14,6 +14,7 @@ from typing import (
     Callable,
     ClassVar,
     Concatenate,
+    Deque,
     Final,
     Generic,
     Literal,
@@ -118,6 +119,17 @@ TYPED_LAMBDA: Callable[[int, int], int] = lambda a, b: a + b
 ANNOTATED_EXTRA: Annotated[str, "extra"] = "x"
 # Nested Annotated usage should merge metadata
 NESTED_ANNOTATED: Annotated[Annotated[int, "a"], "b"] = 3
+
+# Built-in generic without dedicated handler
+GENERIC_DEQUE: Deque[int]
+
+
+# User-defined generic class to exercise GenericNode
+class UserBox(Generic[T]):
+    pass
+
+
+GENERIC_USERBOX: UserBox[int]
 
 
 class Basic:

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,8 +1,9 @@
-# Generated via: macrotype tests/annotations.py -o -
+# Generated via: macrotype tests/annotations.py -o tests/annotations.pyi
 # Do not edit by hand
 # pyright: basic
 from typing import Annotated, Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload, override, runtime_checkable
 from abc import ABC, abstractmethod
+from collections import deque
 from collections.abc import AsyncIterator, Iterator, Sequence
 from dataclasses import InitVar, dataclass
 from enum import Enum, IntEnum, IntFlag
@@ -78,6 +79,9 @@ TYPED_LAMBDA: Callable[[int, int], int]
 ANNOTATED_EXTRA: Annotated[str, 'extra']
 
 NESTED_ANNOTATED: Annotated[int, 'a', 'b']
+
+class UserBox[T]:
+    pass
 
 class Basic:
     simple: list[str]
@@ -436,5 +440,9 @@ TUPLE_VAR: tuple[int, ...]
 SET_VAR: set[int]
 
 FROZENSET_VAR: frozenset[str]
+
+GENERIC_DEQUE: deque[int]
+
+GENERIC_USERBOX: UserBox[int]
 
 LITERAL_STR_VAR: LiteralString

--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -1,3 +1,4 @@
+import collections
 import dataclasses
 import enum
 import typing
@@ -13,6 +14,7 @@ from macrotype.types_ast import (
     DictNode,
     FinalNode,
     FrozenSetNode,
+    GenericNode,
     InitVarNode,
     ListNode,
     LiteralNode,
@@ -44,6 +46,10 @@ T = typing.TypeVar("T")
 P = typing.ParamSpec("P")
 Ts = typing.TypeVarTuple("Ts")
 AliasListT = typing.TypeAliasType("AliasListT", list[T], type_params=(T,))
+
+
+class Box(typing.Generic[T]):
+    pass
 
 
 PARSINGS = {
@@ -109,6 +115,8 @@ PARSINGS = {
         ConcatenateNode([AtomNode(int), VarNode(P)]),
         AtomNode(int),
     ),
+    typing.Deque[int]: GenericNode(collections.deque, (AtomNode(int),)),
+    Box[int]: GenericNode(Box, (AtomNode(int),)),
 }
 
 
@@ -122,9 +130,9 @@ def test_invalid_literal() -> None:
         parse_type(typing.Literal[object()])
 
 
-def test_unsupported_origin() -> None:
-    with pytest.raises(NotImplementedError):
-        parse_type(typing.Deque[int])
+def test_generic_nodes() -> None:
+    assert parse_type(typing.Deque[int]) == GenericNode(collections.deque, (AtomNode(int),))
+    assert parse_type(Box[int]) == GenericNode(Box, (AtomNode(int),))
 
 
 def test_invalid_tuple() -> None:


### PR DESCRIPTION
## Summary
- support generic types without built-in handlers via `GenericNode`
- allow `parse_type` callback to post-process generics
- document generic parsing and callbacks with `Deque` example

## Testing
- `ruff check --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e170d47f08329abbe9a66794b3504