### PR TITLE
Skip submodule __main__ files

### DIFF
--- a/macrotype/stubgen.py
+++ b/macrotype/stubgen.py
@@ -212,7 +212,7 @@ def write_stub(dest: Path, lines: list[str], command: str | None = None) -> None
 def iter_python_files(target: Path) -> list[Path]:
     if target.is_file():
         return [target]
-    return list(target.rglob("*.py"))
+    return [p for p in target.rglob("*.py") if p.name != "__main__.py" or p.parent == target]
 
 
 def process_file(src: Path, dest: Path | None = None, *, command: str | None = None) -> Path:

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -73,6 +73,23 @@ def test_process_directory(tmp_path, src: str, expected: str) -> None:
     assert generated == expected_lines
 
 
+def test_process_directory_skips_dunder_main(tmp_path) -> None:
+    pkg = tmp_path / "pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("# pkg init\n")
+    sub = pkg / "sub"
+    sub.mkdir()
+    (sub / "__init__.py").write_text("# sub init\n")
+    (sub / "__main__.py").write_text("raise RuntimeError('should not import')\n")
+    (sub / "mod.py").write_text("X = 1\n")
+
+    out = tmp_path / "out"
+    process_directory(pkg, out)
+    names = {p.name for p in out.iterdir()}
+    assert "mod.pyi" in names
+    assert "__main__.pyi" not in names
+
+
 def test_module_alias(tmp_path) -> None:
     import pathlib
 


### PR DESCRIPTION
## Summary
- avoid importing `__main__` modules inside subpackages when generating stubs
- exercise the new behavior with a directory-based test

## Testing
- `pytest tests/test_all.py::test_process_directory_skips_dunder_main tests/test_dogfood.py::test_cli_stdlib -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e1c3142a08329bace0c6d982972ce