### PR TITLE
Skip failing stdlib modules

### DIFF
--- a/tests/test_dogfood.py
+++ b/tests/test_dogfood.py
@@ -4,8 +4,6 @@ import sys
 import sysconfig
 from pathlib import Path
 
-import pytest
-
 # Ensure package root on path when running tests directly
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -76,7 +74,6 @@ def test_cli_requires_relative_path(tmp_path: Path) -> None:
     assert "specify -o" in result.stderr
 
 
-@pytest.mark.xfail(reason="CLI cannot yet process the entire stdlib", strict=False)
 def test_cli_stdlib(tmp_path: Path) -> None:
     repo_root = STUBS_DIR.parents[1]
     stdlib = Path(sysconfig.get_path("stdlib"))


### PR DESCRIPTION
## Summary
- ignore CPython's bundled `test` package when collecting modules
- continue processing directory even when a module import fails
- enable stdlib smoke test

## Testing
- `pytest tests/test_dogfood.py::test_cli_stdlib -vv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e1f08c66c8329a8d90a404d24ca7b