### PR TITLE
Validate metadata for Annotated and ParamSpec for Concatenate

### DIFF
--- a/macrotype/types_ast.py
+++ b/macrotype/types_ast.py
@@ -459,6 +459,11 @@ class AnnotatedNode(Generic[N], ContainerNode[N]):
                 "Annotated requires a base type",
                 hint="Annotated[T, ...] must start with a type",
             )
+        if len(args) < 2:
+            raise InvalidTypeError(
+                f"Annotated requires a type and at least one annotation: {args}",
+                hint="Use Annotated[T, ...] with at least one metadata value",
+            )
         base = parse_type(args[0])
         return cls(base, list(args[1:]))
 
@@ -473,6 +478,17 @@ class ConcatenateNode(Generic[N], ContainerNode[N]):
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "ConcatenateNode[N]":
+        if not args:
+            raise InvalidTypeError(
+                "Concatenate requires at least one argument",
+                hint="Concatenate[T, ..., P] expects one or more types ending with a ParamSpec or ...",
+            )
+        last = args[-1]
+        if not (isinstance(last, typing.ParamSpec) or last is Ellipsis):
+            raise InvalidTypeError(
+                f"Concatenate last argument must be a ParamSpec or ellipsis: {last!r}",
+                hint="Use a ParamSpec variable or ... as the final argument",
+            )
         return cls([parse_type(arg) for arg in args])
 
 

--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -212,3 +212,15 @@ def test_nested_required_notrequired() -> None:
         parse_type_expr(list[typing.NotRequired[int]])
     with pytest.raises(TypeError):
         parse_type_expr(list[typing.Required[int]])
+
+
+def test_annotated_requires_metadata() -> None:
+    bad = typing._AnnotatedAlias(int, ())
+    with pytest.raises(InvalidTypeError):
+        parse_type(bad)
+
+
+def test_concatenate_requires_paramspec() -> None:
+    bad = typing._ConcatenateGenericAlias(typing.Concatenate, (int, str))
+    with pytest.raises(InvalidTypeError):
+        parse_type(bad)


### PR DESCRIPTION
## Summary
- require `Annotated` to include at least one metadata element
- validate that `Concatenate` receives a final `ParamSpec` or ellipsis
- add regression tests for these invalid forms

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890f39c311483298dc81b1a92ce11f7