### PR TITLE
Handle single-element tuple annotations

### DIFF
--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype tests/annotations.py -o tests/annotations.pyi
+# Generated via: macrotype tests/annotations.py -o -
 # Do not edit by hand
 # pyright: basic
 from typing import Annotated, Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload, override, runtime_checkable
@@ -278,7 +278,7 @@ class Info(TypedDict):
 
 def with_kwargs(**kwargs: Unpack[Info]) -> Info: ...
 
-def sum_of(*args: tuple[int]) -> int: ...
+def sum_of(*args: tuple[int, ...]) -> int: ...
 
 def dict_echo(**kwargs: dict[str, Any]) -> dict[str, Any]: ...
 

--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -73,12 +73,14 @@ PARSINGS = {
     list[list[int]]: ListNode(ListNode(AtomNode(int))),
     dict[str, list[int]]: DictNode(AtomNode(str), ListNode(AtomNode(int))),
     tuple[()]: TupleNode((), False),
+    tuple[int]: TupleNode((AtomNode(int),), True),
     tuple[int, str]: TupleNode((AtomNode(int), AtomNode(str)), False),
     tuple[int, ...]: TupleNode((AtomNode(int),), True),
     tuple[int, str, ...]: TupleNode(
         (AtomNode(int), AtomNode(str)),
         True,
     ),
+    tuple[typing.Unpack[Ts]]: TupleNode((UnpackNode(VarNode(Ts)),), False),
     set[int]: SetNode(AtomNode(int)),
     frozenset[str]: FrozenSetNode(AtomNode(str)),
     typing.Union[int, str]: UnionNode((AtomNode(int), AtomNode(str))),
@@ -146,6 +148,11 @@ def test_invalid_tuple() -> None:
         parse_type(tuple[..., int])
     with pytest.raises(TypeError):
         parse_type(tuple[int, ..., str])
+
+
+def test_tuple_requires_unpack_typevartuple() -> None:
+    with pytest.raises(TypeError):
+        parse_type(tuple[Ts])
 
 
 def test_invalid_unpack() -> None:


### PR DESCRIPTION
## Summary
- Treat `tuple[T]` as a variadic tuple, reject un-unpacked `TypeVarTuple` and leave `Unpack` alone
- Cover new tuple cases in `types_ast_test`
- Regenerate annotations stub to reflect tuple ellipsis behavior

## Testing
- `ruff check --fix macrotype/types_ast.py tests/types_ast_test.py`
- `python -m macrotype tests/annotations.py -o - > tests/annotations.pyi`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f7fd6f7883299ae44609a50618b0