### PR TITLE
Add optional disallow-any-generics flag

### DIFF
--- a/__macrotype__/macrotype/types_ast.pyi
+++ b/__macrotype__/macrotype/types_ast.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype macrotype -o __macrotype__/macrotype
+# Generated via: macrotype macrotype -o /tmp/macrotype_stubs
 # Do not edit by hand
 from typing import Any, Callable, ClassVar, ParamSpec, TypeVar, TypeVarTuple, Unpack, _TypedDictMeta
 from dataclasses import dataclass
@@ -217,9 +217,11 @@ def _parse_origin_type(origin: Any, args: tuple[Any, ...], raw: Any) -> BaseNode
 
 _on_generic_callback: Callable[[GenericNode], BaseNode] | None
 
-def parse_type(typ: Any, *, on_generic: Callable[[GenericNode], BaseNode] | None) -> BaseNode: ...
+_disallow_any_generics: bool
 
-def parse_type_expr(typ: Any) -> TypeExprNode: ...
+def parse_type(typ: Any, *, on_generic: Callable[[GenericNode], BaseNode] | None, disallow_any_generics: bool | None) -> BaseNode: ...
+
+def parse_type_expr(typ: Any, *, disallow_any_generics: bool | None) -> TypeExprNode: ...
 
 def _reject_special(node: BaseNode) -> None: ...
 

--- a/__macrotype__/macrotype/types_ast.pyi
+++ b/__macrotype__/macrotype/types_ast.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype macrotype -o /tmp/macrotype_stubs
+# Generated via: macrotype macrotype/types_ast.py -o -
 # Do not edit by hand
 from typing import Any, Callable, ClassVar, ParamSpec, TypeVar, TypeVarTuple, Unpack, _TypedDictMeta
 from dataclasses import dataclass
@@ -217,11 +217,11 @@ def _parse_origin_type(origin: Any, args: tuple[Any, ...], raw: Any) -> BaseNode
 
 _on_generic_callback: Callable[[GenericNode], BaseNode] | None
 
-_disallow_any_generics: bool
+_strict: bool
 
-def parse_type(typ: Any, *, on_generic: Callable[[GenericNode], BaseNode] | None, disallow_any_generics: bool | None) -> BaseNode: ...
+def parse_type(typ: Any, *, on_generic: Callable[[GenericNode], BaseNode] | None, strict: bool | None) -> BaseNode: ...
 
-def parse_type_expr(typ: Any, *, disallow_any_generics: bool | None) -> TypeExprNode: ...
+def parse_type_expr(typ: Any, *, strict: bool | None) -> TypeExprNode: ...
 
 def _reject_special(node: BaseNode) -> None: ...
 

--- a/macrotype/types_ast.py
+++ b/macrotype/types_ast.py
@@ -203,13 +203,30 @@ class DictNode(Generic[K, V], ContainerNode[typing.Union[K, V]]):
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "DictNode[K, V]":
-        if len(args) > 2:
+        if len(args) == 0:
+            if _disallow_any_generics:
+                raise InvalidTypeError(
+                    "dict requires explicit key and value types",
+                    hint="Use dict[key_type, value_type]",
+                )
+            key = AtomNode(typing.Any)
+            val = AtomNode(typing.Any)
+        elif len(args) == 1:
+            if _disallow_any_generics:
+                raise InvalidTypeError(
+                    "dict requires explicit value type",
+                    hint="Use dict[key_type, value_type]",
+                )
+            key = parse_type(args[0])
+            val = AtomNode(typing.Any)
+        elif len(args) == 2:
+            key = parse_type(args[0])
+            val = parse_type(args[1])
+        else:
             raise InvalidTypeError(
                 f"Too many arguments to dict: {args}",
-                hint="dict accepts at most two type arguments",
+                hint="Use dict[key_type, value_type]",
             )
-        key = parse_type(args[0]) if len(args) > 0 else AtomNode(typing.Any)
-        val = parse_type(args[1]) if len(args) > 1 else AtomNode(typing.Any)
         return cls(key, val)
 
 
@@ -224,12 +241,20 @@ class ListNode(Generic[N], ContainerNode[N]):
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "ListNode[N]":
-        if len(args) > 1:
+        if len(args) == 0:
+            if _disallow_any_generics:
+                raise InvalidTypeError(
+                    "list requires a type argument",
+                    hint="Use list[element_type]",
+                )
+            elem = AtomNode(typing.Any)
+        elif len(args) == 1:
+            elem = parse_type(args[0])
+        else:
             raise InvalidTypeError(
                 f"Too many arguments to list: {args}",
                 hint="list accepts at most one type argument",
             )
-        elem = parse_type(args[0]) if args else AtomNode(typing.Any)
         return cls(elem)
 
 
@@ -283,12 +308,20 @@ class SetNode(Generic[N], ContainerNode[N]):
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "SetNode[N]":
-        if len(args) > 1:
+        if len(args) == 0:
+            if _disallow_any_generics:
+                raise InvalidTypeError(
+                    "set requires a type argument",
+                    hint="Use set[element_type]",
+                )
+            elem = AtomNode(typing.Any)
+        elif len(args) == 1:
+            elem = parse_type(args[0])
+        else:
             raise InvalidTypeError(
                 f"Too many arguments to set: {args}",
                 hint="set accepts at most one type argument",
             )
-        elem = parse_type(args[0]) if args else AtomNode(typing.Any)
         return cls(elem)
 
 
@@ -303,12 +336,20 @@ class FrozenSetNode(Generic[N], ContainerNode[N]):
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "FrozenSetNode[N]":
-        if len(args) > 1:
+        if len(args) == 0:
+            if _disallow_any_generics:
+                raise InvalidTypeError(
+                    "frozenset requires a type argument",
+                    hint="Use frozenset[element_type]",
+                )
+            elem = AtomNode(typing.Any)
+        elif len(args) == 1:
+            elem = parse_type(args[0])
+        else:
             raise InvalidTypeError(
                 f"Too many arguments to frozenset: {args}",
                 hint="frozenset accepts at most one type argument",
             )
-        elem = parse_type(args[0]) if args else AtomNode(typing.Any)
         return cls(elem)
 
 
@@ -583,6 +624,12 @@ class UnpackNode(SpecialFormNode):
 
 
 def _parse_no_origin_type(typ: Any) -> BaseNode:
+    if _disallow_any_generics and isinstance(typ, type) and issubclass(typ, typing.Generic):
+        if getattr(typ, "__parameters__", ()):  # pragma: no branch
+            raise InvalidTypeError(
+                f"{typ.__qualname__} requires type arguments",
+                hint=f"Use {typ.__qualname__}[...]",
+            )
     if isinstance(typ, (typing.TypeVar, typing.ParamSpec, typing.TypeVarTuple)):
         return VarNode(typ)
     if isinstance(typ, TypeAliasType):
@@ -590,6 +637,11 @@ def _parse_no_origin_type(typ: Any) -> BaseNode:
     node_cls = BaseNode._registry.get(typ)
     if node_cls is not None:
         if node_cls is TupleNode:
+            if _disallow_any_generics:
+                raise InvalidTypeError(
+                    "tuple requires a type argument",
+                    hint="Use tuple[T, ...] or tuple[T1, T2]",
+                )
             return TupleNode((AtomNode(typing.Any),), True)
         return node_cls.for_args(())
     if isinstance(typ, typing._TypedDictMeta):
@@ -608,6 +660,20 @@ def _parse_origin_type(origin: Any, args: tuple[Any, ...], raw: Any) -> BaseNode
     node_cls = BaseNode._registry.get(origin)
     if node_cls is not None:
         return node_cls.for_args(args)
+    if (
+        not args
+        and _disallow_any_generics
+        and (
+            (isinstance(origin, type) and issubclass(origin, typing.Generic))
+            or hasattr(origin, "__parameters__")
+            or hasattr(raw, "__parameters__")
+        )
+    ):
+        name = getattr(origin, "__qualname__", repr(origin))
+        raise InvalidTypeError(
+            f"{name} requires type arguments",
+            hint=f"Use {name}[...]",
+        )
     if args and (
         (isinstance(origin, type) and issubclass(origin, typing.Generic))
         or hasattr(origin, "__parameters__")
@@ -621,10 +687,14 @@ def _parse_origin_type(origin: Any, args: tuple[Any, ...], raw: Any) -> BaseNode
 
 
 _on_generic_callback: Callable[[GenericNode], BaseNode] | None = None
+_disallow_any_generics: bool = False
 
 
 def parse_type(
-    typ: Any, *, on_generic: Callable[[GenericNode], BaseNode] | None = None
+    typ: Any,
+    *,
+    on_generic: Callable[[GenericNode], BaseNode] | None = None,
+    disallow_any_generics: bool | None = None,
 ) -> BaseNode:
     """Parse *typ* into a :class:`BaseNode`.
 
@@ -632,10 +702,13 @@ def parse_type(
     produced during parsing, allowing custom post-processing of generic types.
     """
 
-    global _on_generic_callback
-    prev = _on_generic_callback
+    global _on_generic_callback, _disallow_any_generics
+    prev_cb = _on_generic_callback
+    prev_flag = _disallow_any_generics
     if on_generic is not None:
         _on_generic_callback = on_generic
+    if disallow_any_generics is not None:
+        _disallow_any_generics = disallow_any_generics
     try:
         if isinstance(typ, (typing.ParamSpecArgs, typing.ParamSpecKwargs)):
             node = AtomNode(typ)
@@ -650,13 +723,15 @@ def parse_type(
         return node
     finally:
         if on_generic is not None:
-            _on_generic_callback = prev
+            _on_generic_callback = prev_cb
+        if disallow_any_generics is not None:
+            _disallow_any_generics = prev_flag
 
 
-def parse_type_expr(typ: Any) -> TypeExprNode:
+def parse_type_expr(typ: Any, *, disallow_any_generics: bool | None = None) -> TypeExprNode:
     """Parse *typ* ensuring it is a :class:`TypeExprNode`."""
 
-    node = parse_type(typ)
+    node = parse_type(typ, disallow_any_generics=disallow_any_generics)
     _reject_special(node)
     return typing.cast(TypeExprNode, node)
 

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -99,6 +99,8 @@ TUPLE_VAR: tuple[int, ...]
 # Variable using set and frozenset types to test container formatting
 SET_VAR: set[int]
 FROZENSET_VAR: frozenset[str]
+# Dict without explicit value type should default to Any
+DICT_WITH_IMPLICIT_ANY: dict[int]
 
 # Edge case: annotated constants with values should honor the annotation
 ANNOTATED_FINAL: Final[int] = 5

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -444,6 +444,8 @@ SET_VAR: set[int]
 
 FROZENSET_VAR: frozenset[str]
 
+DICT_WITH_IMPLICIT_ANY: dict[int, Any]
+
 GENERIC_DEQUE: deque[int]
 
 GENERIC_USERBOX: UserBox[int]

--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -66,6 +66,7 @@ PARSINGS = {
     set: SetNode(AtomNode(typing.Any)),
     frozenset: FrozenSetNode(AtomNode(typing.Any)),
     dict[()]: DictNode(AtomNode(typing.Any), AtomNode(typing.Any)),
+    dict[int]: DictNode(AtomNode(int), AtomNode(typing.Any)),
     dict[int, str]: DictNode(AtomNode(int), AtomNode(str)),
     dict[int, typing.Any]: DictNode(AtomNode(int), AtomNode(typing.Any)),
     list[()]: ListNode(AtomNode(typing.Any)),
@@ -158,6 +159,15 @@ def test_tuple_requires_unpack_typevartuple() -> None:
 def test_invalid_unpack() -> None:
     with pytest.raises(TypeError):
         parse_type(typing.Unpack[list[int]])
+
+
+def test_disallow_any_generics_flag() -> None:
+    with pytest.raises(InvalidTypeError):
+        parse_type(dict[int], disallow_any_generics=True)
+    with pytest.raises(InvalidTypeError):
+        parse_type(list, disallow_any_generics=True)
+    with pytest.raises(InvalidTypeError):
+        parse_type(Box, disallow_any_generics=True)
 
 
 def test_invalid_initvar() -> None:

--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -161,13 +161,13 @@ def test_invalid_unpack() -> None:
         parse_type(typing.Unpack[list[int]])
 
 
-def test_disallow_any_generics_flag() -> None:
+def test_strict_flag() -> None:
     with pytest.raises(InvalidTypeError):
-        parse_type(dict[int], disallow_any_generics=True)
+        parse_type(dict[int], strict=True)
     with pytest.raises(InvalidTypeError):
-        parse_type(list, disallow_any_generics=True)
+        parse_type(list, strict=True)
     with pytest.raises(InvalidTypeError):
-        parse_type(Box, disallow_any_generics=True)
+        parse_type(Box, strict=True)
 
 
 def test_invalid_initvar() -> None:


### PR DESCRIPTION
## Summary
- make implicit `Any` in generic containers opt-in
- allow `dict[int]` by default but error when `disallow_any_generics` is set
- test flag behaviour and document implicit `Any` handling

## Testing
- `python -m macrotype tests/annotations.py -o - > tests/annotations.pyi`
- `ruff format macrotype/types_ast.py tests/annotations.py tests/test_invalid_typing.py tests/types_ast_test.py __macrotype__/macrotype/types_ast.pyi`
- `ruff check --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891256c575c832992d1cb01e1ca8e2a