### PR TITLE
Add metaprogramming demo and documentation

### DIFF
--- a/demos/sqla_demos.py
+++ b/demos/sqla_demos.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import sys
+from typing import Generic, NewType, TypeVar
+
+T = TypeVar("T")
+
+
+class Mapped(Generic[T]):
+    """Placeholder for ``sqlalchemy.orm.Mapped``."""
+
+
+class Base:
+    def __init_subclass__(cls) -> None:  # noqa: D401 - simple demo
+        typename = f"{cls.__name__}Id"
+        new_type = NewType(typename, int)
+        cls.id_type = new_type
+        cls.__annotations__["id"] = Mapped[new_type]
+        cls.__annotations__["id_type"] = type[new_type]
+        mod = sys.modules[cls.__module__]
+        setattr(mod, typename, new_type)
+
+
+class Manager(Base): ...
+
+
+class Employee(Base):
+    manager_id: Mapped[Manager.id_type]

--- a/demos/sqla_demos.pyi
+++ b/demos/sqla_demos.pyi
@@ -1,0 +1,25 @@
+# Generated via: macrotype demos/sqla_demos.py -o demos/sqla_demos.pyi
+# Do not edit by hand
+from typing import NewType, TypeVar
+
+T = TypeVar("T")
+
+class Mapped[T]:
+    pass
+
+class Base:
+    @classmethod
+    def __init_subclass__(cls) -> None: ...
+
+ManagerId = NewType("ManagerId", int)
+
+class Manager(Base):
+    id: Mapped[ManagerId]
+    id_type: type[ManagerId]
+
+EmployeeId = NewType("EmployeeId", int)
+
+class Employee(Base):
+    manager_id: Mapped[ManagerId]
+    id: Mapped[EmployeeId]
+    id_type: type[EmployeeId]

--- a/docs/demos.rst
+++ b/docs/demos.rst
@@ -1,0 +1,14 @@
+Metaprogramming demos
+=====================
+
+``macrotype`` can capture types that are generated dynamically.  The example
+below creates a new ``NewType`` for each subclass using ``__init_subclass__``.
+This pattern is similar to how SQLAlchemy models can define typed primary keys.
+
+.. literalinclude:: ../demos/sqla_demos.py
+   :language: python
+
+Running ``macrotype`` generates the following stub:
+
+.. literalinclude:: ../demos/sqla_demos.pyi
+   :language: python

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,3 +25,8 @@ Module Documentation
 .. automodule:: macrotype
     :members:
 
+.. toctree::
+   :maxdepth: 1
+
+   demos
+

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -3,6 +3,7 @@ import collections.abc as cabc
 import functools
 import math
 import re
+import sys
 from abc import ABC, abstractmethod
 from dataclasses import InitVar, dataclass
 from enum import Enum, IntEnum, IntFlag
@@ -748,3 +749,24 @@ class AbstractBase(ABC):
 class BadParams:
     __parameters__ = 1
     value: int
+
+
+# Demo: dynamically generate a NewType per subclass
+class Mapped(Generic[T]): ...
+
+
+class SQLBase:
+    def __init_subclass__(cls) -> None:
+        typename = f"{cls.__name__}Id"
+        new_type = NewType(typename, int)
+        cls.id_type = new_type
+        cls.__annotations__["id"] = Mapped[new_type]
+        cls.__annotations__["id_type"] = type[new_type]
+        sys.modules[cls.__module__].__dict__[typename] = new_type
+
+
+class ManagerModel(SQLBase): ...
+
+
+class EmployeeModel(SQLBase):
+    manager_id: Mapped[ManagerModel.id_type]

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype tests/annotations.py -o -
+# Generated via: macrotype tests/annotations.py -o tests/annotations.pyi
 # Do not edit by hand
 # pyright: basic
 from typing import Annotated, Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload, override, runtime_checkable
@@ -429,6 +429,26 @@ class AbstractBase(ABC):
 
 class BadParams:
     value: int
+
+class Mapped[T]:
+    pass
+
+class SQLBase:
+    @classmethod
+    def __init_subclass__(cls) -> None: ...
+
+ManagerModelId = NewType('ManagerModelId', int)
+
+class ManagerModel(SQLBase):
+    id: Mapped[ManagerModelId]
+    id_type: type[ManagerModelId]
+
+EmployeeModelId = NewType('EmployeeModelId', int)
+
+class EmployeeModel(SQLBase):
+    manager_id: Mapped[ManagerModelId]
+    id: Mapped[EmployeeModelId]
+    id_type: type[EmployeeModelId]
 
 GLOBAL: int
 


### PR DESCRIPTION
## Summary
- add a `demos` module showing how `__init_subclass__` can create `NewType` ids for subclasses
- document the demo and link it from the docs index
- exercise dynamic id generation in test annotations
- expose `id_type` on each subclass and show cross-model references

## Testing
- `ruff format demos tests docs`
- `ruff check --fix demos tests/annotations.py docs`
- `pytest`
- `sphinx-build docs docs/_build` *(fails: command not found)*
- `pip install sphinx sphinx-rtd-theme` *(fails: Could not find a version that satisfies the requirement sphinx)*

------
https://chatgpt.com/codex/tasks/task_e_6892566d68688329ad3d8757d0ae2766