### PR TITLE
Configure MyPy to ignore generated stubs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,7 +65,13 @@ checker command followed by the paths to stub.  Any additional arguments after
     macrotype-check mypy src/ -- --strict
 
 Stubs are written to ``__macrotype__`` by default; use ``-o`` to choose a
-different directory.
+different directory.  When run with ``mypy``, ``macrotype-check`` prepends the
+stub directory to ``MYPYPATH`` so the overlay stubs are picked up
+automatically.  Other tools receive the stub directory on ``PYTHONPATH``.
+
+If you run ``mypy`` without ``macrotype-check``, set ``MYPYPATH`` or pass
+``--custom-typeshed-dir`` to point at the stub directory so it behaves the same
+way.
 
 Watch mode
 ----------

--- a/macrotype/typecheck.py
+++ b/macrotype/typecheck.py
@@ -65,8 +65,12 @@ def main(argv: list[str] | None = None) -> int:
     stub_paths = _generate_stubs(args.paths, out_dir, command)
 
     env = os.environ.copy()
-    env["PYTHONPATH"] = str(out_dir) + os.pathsep + env.get("PYTHONPATH", "")
-    result = subprocess.run([args.tool, *map(str, stub_paths), *tool_args], env=env)
+    stub_path = str(out_dir)
+    env_path = "MYPYPATH" if args.tool == "mypy" else "PYTHONPATH"
+    env[env_path] = stub_path + os.pathsep + env.get(env_path, "")
+
+    cmd = [args.tool, *map(str, stub_paths), *tool_args]
+    result = subprocess.run(cmd, env=env)
     return result.returncode
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,6 @@ exclude = [
 [tool.ruff.lint]
 extend-select = ["I"]
 ignore = ["E402", "E731", "F811", "F841"]
+
+[tool.mypy]
+exclude = "^__macrotype__/"


### PR DESCRIPTION
## Summary
- exclude generated `__macrotype__` overlay from MyPy via `pyproject.toml`
- ensure `macrotype-check` injects stub directory into `MYPYPATH` (or `PYTHONPATH` for other tools) so `macrotype-check mypy` works out of the box
- document that `macrotype-check` handles `MYPYPATH` automatically and how to run MyPy directly

## Testing
- `ruff format`
- `ruff check --fix`
- `pytest`
- `python -m macrotype.typecheck mypy tests/annotations.py`
- `MYPYPATH=__macrotype__ mypy macrotype` *(fails: many type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68950339a31c8329a70ddbbd3a61acba