### PR TITLE
Include inherited annotations in meta type helpers

### DIFF
--- a/__macrotype__/macrotype/meta_types.pyi
+++ b/__macrotype__/macrotype/meta_types.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype macrotype
+# Generated via: macrotype macrotype/meta_types.py -o __macrotype__/macrotype/meta_types.pyi
 # Do not edit by hand
 from typing import Any, Callable
 
@@ -31,6 +31,8 @@ _NoneType = NoneType
 def _make_class(name: str, annotations: dict[str, Any]) -> type: ...
 
 def _strip_type(ann: Any, null: Any) -> Any: ...
+
+def all_annotations(cls: type) -> dict[str, Any]: ...
 
 def optional(name: str, cls: type, *, null: Any) -> type: ...
 

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -809,6 +809,19 @@ FinalCls = mt.final("FinalCls", Cls)
 ReplacedCls = mt.replace("ReplacedCls", Cls, {"a": str, "b": bool})
 
 
+# meta_types with inherited annotations
+class BaseInherit:
+    base: int
+
+
+class SubInherit(BaseInherit):
+    sub: str
+
+
+InheritedOmit = mt.omit("InheritedOmit", SubInherit, ["sub"])
+InheritedFinal = mt.final("InheritedFinal", SubInherit)
+
+
 # optional() and required() with a custom null sentinel
 class Undefined: ...
 

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -490,6 +490,19 @@ class ReplacedCls:
     c: str | None
     d: bytes
 
+class BaseInherit:
+    base: int
+
+class SubInherit(BaseInherit):
+    sub: str
+
+class InheritedOmit:
+    base: int
+
+class InheritedFinal:
+    base: Final[int]
+    sub: Final[str]
+
 class Undefined: ...
 
 class UndefinedCls:

--- a/tests/test_meta_types.py
+++ b/tests/test_meta_types.py
@@ -2,10 +2,14 @@ import typing
 
 from macrotype.meta_types import (
     clear_registry,
+    final,
     get_overloads,
+    omit,
     optional,
     overload,
     patch_typing,
+    pick,
+    replace,
     required,
 )
 
@@ -23,6 +27,28 @@ def test_patch_typing_updates_typing_registry():
     clear_registry()
     assert typing.get_overloads(local) == []
     assert get_overloads(local) == []
+
+
+def test_meta_type_functions_include_bases():
+    class Base:
+        x: int
+
+    class Child(Base):
+        y: str
+
+    Opt = optional("Opt", Child)
+    Req = required("Req", Child)
+    Pik = pick("Pik", Child, ["x", "y"])
+    Om = omit("Om", Child, ["y"])
+    Fin = final("Fin", Child)
+    Rep = replace("Rep", Child, {"z": float})
+
+    assert Opt.__annotations__ == {"x": int | None, "y": str | None}
+    assert Req.__annotations__ == {"x": int, "y": str}
+    assert Pik.__annotations__ == {"x": int, "y": str}
+    assert Om.__annotations__ == {"x": int}
+    assert Fin.__annotations__ == {"x": typing.Final[int], "y": typing.Final[str]}
+    assert Rep.__annotations__ == {"x": int, "y": str, "z": float}
 
 
 def test_optional_required_custom_null():


### PR DESCRIPTION
## Summary
- add `all_annotations` helper to aggregate inherited class annotations
- update optional/required/pick/omit/final/replace to include base annotations
- expand tests and annotation fixtures for inherited meta type behavior

## Testing
- `ruff check --fix .`
- `pytest tests/test_meta_types.py tests/test_all.py`

------
https://chatgpt.com/codex/tasks/task_e_68950fd93c188329b63904ad75d79e4e