### PR TITLE
Flatten typing modifiers into core nodes

### DIFF
--- a/__macrotype__/macrotype/types_ast.pyi
+++ b/__macrotype__/macrotype/types_ast.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype macrotype
+# Generated via: macrotype macrotype -o __macrotype__/macrotype
 # Do not edit by hand
 from typing import Any, Callable, ClassVar, ParamSpec, TypeVar, TypeVarTuple, Unpack, _TypedDictMeta
 from dataclasses import dataclass
@@ -10,17 +10,25 @@ class InvalidTypeError(TypeError):
     def __init__(self, message: str, *, hint: str | None, file: str | None, line: int | None) -> None: ...
     def __str__(self) -> str: ...
 
+@dataclass(frozen=True, kw_only=True)
 class BaseNode:
+    annotated_metadata: list[Any]
+    is_final: bool
+    is_required: bool | None
     _registry: ClassVar[dict[Any, type[BaseNode]]]
     handles: ClassVar[tuple[Any, ...]]
     @classmethod
     def __init_subclass__(cls, **kwargs: Any) -> None: ...
     def emit(self) -> Any: ...
+    def _apply_modifiers(self, t: Any) -> Any: ...
 
+@dataclass(frozen=True, kw_only=True)
 class TypeExprNode(BaseNode): ...
 
+@dataclass(frozen=True, kw_only=True)
 class InClassExprNode(BaseNode): ...
 
+@dataclass(frozen=True, kw_only=True)
 class SpecialFormNode(BaseNode): ...
 
 N = TypeVar('N')
@@ -31,6 +39,7 @@ V = TypeVar('V')
 
 Ctx = TypeVarTuple('Ctx')
 
+@dataclass(frozen=True, kw_only=True)
 class ContainerNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](BaseNode): ...
 
 type NodeLike[N] = N | ContainerNode[N]
@@ -126,6 +135,13 @@ class SelfNode(InClassExprNode):
     def for_args(cls, args: tuple[Any, ...]) -> SelfNode: ...
 
 @dataclass(frozen=True)
+class FinalNode(SpecialFormNode):
+    handles: ClassVar[tuple[Any, ...]]
+    def emit(self) -> Any: ...
+    @classmethod
+    def for_args(cls, args: tuple[Any, ...]) -> FinalNode: ...
+
+@dataclass(frozen=True)
 class ClassVarNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N], InClassExprNode):
     handles: ClassVar[tuple[Any, ...]]
     inner: NodeLike[N]
@@ -134,45 +150,12 @@ class ClassVarNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerN
     def for_args(cls, args: tuple[Any, ...]) -> ClassVarNode[N]: ...
 
 @dataclass(frozen=True)
-class FinalNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N], SpecialFormNode):
-    handles: ClassVar[tuple[Any, ...]]
-    inner: NodeLike[N]
-    def emit(self) -> Any: ...
-    @classmethod
-    def for_args(cls, args: tuple[Any, ...]) -> FinalNode[N]: ...
-
-@dataclass(frozen=True)
-class RequiredNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N], InClassExprNode):
-    handles: ClassVar[tuple[Any, ...]]
-    inner: NodeLike[N]
-    def emit(self) -> Any: ...
-    @classmethod
-    def for_args(cls, args: tuple[Any, ...]) -> RequiredNode[N]: ...
-
-@dataclass(frozen=True)
-class NotRequiredNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N], InClassExprNode):
-    handles: ClassVar[tuple[Any, ...]]
-    inner: NodeLike[N]
-    def emit(self) -> Any: ...
-    @classmethod
-    def for_args(cls, args: tuple[Any, ...]) -> NotRequiredNode[N]: ...
-
-@dataclass(frozen=True)
 class TypeGuardNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N], SpecialFormNode):
     handles: ClassVar[tuple[Any, ...]]
     target: NodeLike[N]
     def emit(self) -> Any: ...
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> TypeGuardNode[N]: ...
-
-@dataclass(frozen=True)
-class AnnotatedNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N]):
-    handles: ClassVar[tuple[Any, ...]]
-    base: NodeLike[N]
-    metadata: list[Any]
-    def emit(self) -> Any: ...
-    @classmethod
-    def for_args(cls, args: tuple[Any, ...]) -> AnnotatedNode[N]: ...
 
 @dataclass(frozen=True)
 class ConcatenateNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N]):

--- a/macrotype/types_ast.py
+++ b/macrotype/types_ast.py
@@ -6,7 +6,7 @@ import dataclasses
 import enum
 import types
 import typing
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import (
     Any,
     Callable,
@@ -45,8 +45,13 @@ class InvalidTypeError(TypeError):
         return f"{location}{self.args[0]}{hint}"
 
 
+@dataclass(frozen=True, kw_only=True)
 class BaseNode:
     """Base class for parsed type nodes."""
+
+    annotated_metadata: list[Any] = field(default_factory=list)
+    is_final: bool = False
+    is_required: bool | None = None
 
     # Registry mapping handled typing "things" to node classes
     _registry: ClassVar[dict[Any, type["BaseNode"]]] = {}
@@ -62,6 +67,17 @@ class BaseNode:
     def emit(self) -> TypeExpr:
         """Return the Python type expression represented by this node."""
         raise NotImplementedError(f"{self.__class__.__name__} must implement emit()")
+
+    def _apply_modifiers(self, t: TypeExpr) -> TypeExpr:
+        if self.is_required is True:
+            t = typing.Required[t]
+        elif self.is_required is False:
+            t = typing.NotRequired[t]
+        if self.is_final:
+            t = typing.Final[t]
+        if self.annotated_metadata:
+            t = typing.Annotated[t, *self.annotated_metadata]
+        return t
 
 
 class TypeExprNode(BaseNode):
@@ -115,7 +131,7 @@ class AtomNode(TypeExprNode):
     type_: Any
 
     def emit(self) -> TypeExpr:
-        return self.type_
+        return self._apply_modifiers(self.type_)
 
     @staticmethod
     def is_atom(type_: Any) -> bool:
@@ -149,7 +165,7 @@ class VarNode(TypeExprNode):
     var: typing.TypeVar | typing.ParamSpec | typing.TypeVarTuple
 
     def emit(self) -> TypeExpr:
-        return self.var
+        return self._apply_modifiers(self.var)
 
 
 @dataclass(frozen=True)
@@ -167,7 +183,7 @@ class GenericNode(ContainerNode[TypeExprNode]):
     args: tuple[BaseNode, ...]
 
     def emit(self) -> TypeExpr:
-        return self.origin[tuple(arg.emit() for arg in self.args)]
+        return self._apply_modifiers(self.origin[tuple(arg.emit() for arg in self.args)])
 
 
 @dataclass(frozen=True)
@@ -176,7 +192,7 @@ class LiteralNode(TypeExprNode):
     values: list[int | str | bool | enum.Enum | None]
 
     def emit(self) -> TypeExpr:
-        return typing.Literal[tuple(self.values)]
+        return self._apply_modifiers(typing.Literal[tuple(self.values)])
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "LiteralNode":
@@ -199,7 +215,7 @@ class DictNode(Generic[K, V], ContainerNode[typing.Union[K, V]]):
     value: NodeLike[V]
 
     def emit(self) -> TypeExpr:
-        return dict[self.key.emit(), self.value.emit()]
+        return self._apply_modifiers(dict[self.key.emit(), self.value.emit()])
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> BaseNode:
@@ -235,7 +251,7 @@ class ListNode(Generic[N], ContainerNode[N]):
     container_type: ClassVar[type] = list
 
     def emit(self) -> TypeExpr:
-        return list[self.element.emit()]
+        return self._apply_modifiers(list[self.element.emit()])
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> BaseNode:
@@ -271,7 +287,7 @@ class TupleNode(Generic[*Ctx], ContainerNode[typing.Union[*Ctx]]):
         args = tuple(item.emit() for item in self.items)
         if self.variable:
             args += (Ellipsis,)
-        return tuple[args]
+        return self._apply_modifiers(tuple[args])
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "TupleNode[N]":
@@ -301,7 +317,7 @@ class SetNode(Generic[N], ContainerNode[N]):
     container_type: ClassVar[type] = set
 
     def emit(self) -> TypeExpr:
-        return set[self.element.emit()]
+        return self._apply_modifiers(set[self.element.emit()])
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> BaseNode:
@@ -328,7 +344,7 @@ class FrozenSetNode(Generic[N], ContainerNode[N]):
     container_type: ClassVar[type] = frozenset
 
     def emit(self) -> TypeExpr:
-        return frozenset[self.element.emit()]
+        return self._apply_modifiers(frozenset[self.element.emit()])
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> BaseNode:
@@ -356,7 +372,7 @@ class InitVarNode(SpecialFormNode):
     inner: TypeExprNode
 
     def emit(self) -> TypeExpr:
-        return dataclasses.InitVar[self.inner.emit()]
+        return self._apply_modifiers(dataclasses.InitVar[self.inner.emit()])
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "InitVarNode":
@@ -388,6 +404,24 @@ class SelfNode(InClassExprNode):
 
 
 @dataclass(frozen=True)
+class FinalNode(SpecialFormNode):
+    handles: ClassVar[tuple[Any, ...]] = (typing.Final,)
+    """Bare ``typing.Final`` marker with inferred type."""
+
+    def emit(self) -> TypeExpr:
+        return self._apply_modifiers(typing.Final)
+
+    @classmethod
+    def for_args(cls, args: tuple[Any, ...]) -> "FinalNode":
+        if args:
+            raise InvalidTypeError(
+                f"Final takes no arguments: {args}",
+                hint="Use Final[T] with a type argument",
+            )
+        return cls()
+
+
+@dataclass(frozen=True)
 class ClassVarNode(Generic[N], ContainerNode[N], InClassExprNode):
     handles: ClassVar[tuple[Any, ...]] = (typing.ClassVar,)
     """``typing.ClassVar`` wrapper."""
@@ -395,7 +429,7 @@ class ClassVarNode(Generic[N], ContainerNode[N], InClassExprNode):
     inner: NodeLike[N]
 
     def emit(self) -> TypeExpr:
-        return typing.ClassVar[self.inner.emit()]
+        return self._apply_modifiers(typing.ClassVar[self.inner.emit()])
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "ClassVarNode[N]":
@@ -409,67 +443,6 @@ class ClassVarNode(Generic[N], ContainerNode[N], InClassExprNode):
 
 
 @dataclass(frozen=True)
-class FinalNode(Generic[N], ContainerNode[N], SpecialFormNode):
-    handles: ClassVar[tuple[Any, ...]] = (typing.Final,)
-    """``typing.Final`` wrapper."""
-
-    inner: NodeLike[N]
-
-    def emit(self) -> TypeExpr:
-        return typing.Final[self.inner.emit()]
-
-    @classmethod
-    def for_args(cls, args: tuple[Any, ...]) -> "FinalNode[N]":
-        if len(args) > 1:
-            raise InvalidTypeError(
-                f"Final takes at most one argument: {args}",
-                hint="Final[T] accepts a single type argument",
-            )
-        inner = parse_type(args[0]) if args else AtomNode(typing.Any)
-        return cls(inner)
-
-
-@dataclass(frozen=True)
-class RequiredNode(Generic[N], ContainerNode[N], InClassExprNode):
-    handles: ClassVar[tuple[Any, ...]] = (typing.Required,)
-    """``typing.Required`` wrapper."""
-
-    inner: NodeLike[N]
-
-    def emit(self) -> TypeExpr:
-        return typing.Required[self.inner.emit()]
-
-    @classmethod
-    def for_args(cls, args: tuple[Any, ...]) -> "RequiredNode[N]":
-        if len(args) != 1:
-            raise InvalidTypeError(
-                f"Required requires a single argument: {args}",
-                hint="Required[T] expects exactly one argument",
-            )
-        return cls(parse_type(args[0]))
-
-
-@dataclass(frozen=True)
-class NotRequiredNode(Generic[N], ContainerNode[N], InClassExprNode):
-    handles: ClassVar[tuple[Any, ...]] = (typing.NotRequired,)
-    """``typing.NotRequired`` wrapper."""
-
-    inner: NodeLike[N]
-
-    def emit(self) -> TypeExpr:
-        return typing.NotRequired[self.inner.emit()]
-
-    @classmethod
-    def for_args(cls, args: tuple[Any, ...]) -> "NotRequiredNode[N]":
-        if len(args) != 1:
-            raise InvalidTypeError(
-                f"NotRequired requires a single argument: {args}",
-                hint="NotRequired[T] expects exactly one argument",
-            )
-        return cls(parse_type(args[0]))
-
-
-@dataclass(frozen=True)
 class TypeGuardNode(Generic[N], ContainerNode[N], SpecialFormNode):
     handles: ClassVar[tuple[Any, ...]] = (typing.TypeGuard,)
     """``typing.TypeGuard`` wrapper."""
@@ -477,7 +450,7 @@ class TypeGuardNode(Generic[N], ContainerNode[N], SpecialFormNode):
     target: NodeLike[N]
 
     def emit(self) -> TypeExpr:
-        return typing.TypeGuard[self.target.emit()]
+        return self._apply_modifiers(typing.TypeGuard[self.target.emit()])
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "TypeGuardNode[N]":
@@ -490,37 +463,12 @@ class TypeGuardNode(Generic[N], ContainerNode[N], SpecialFormNode):
 
 
 @dataclass(frozen=True)
-class AnnotatedNode(Generic[N], ContainerNode[N]):
-    handles: ClassVar[tuple[Any, ...]] = (typing.Annotated,)
-    base: NodeLike[N]
-    metadata: list[Any]
-
-    def emit(self) -> TypeExpr:
-        return typing.Annotated[self.base.emit(), *self.metadata]
-
-    @classmethod
-    def for_args(cls, args: tuple[Any, ...]) -> "AnnotatedNode[N]":
-        if not args:
-            raise InvalidTypeError(
-                "Annotated requires a base type",
-                hint="Annotated[T, ...] must start with a type",
-            )
-        if len(args) < 2:
-            raise InvalidTypeError(
-                f"Annotated requires a type and at least one annotation: {args}",
-                hint="Use Annotated[T, ...] with at least one metadata value",
-            )
-        base = parse_type(args[0])
-        return cls(base, list(args[1:]))
-
-
-@dataclass(frozen=True)
 class ConcatenateNode(Generic[N], ContainerNode[N]):
     handles: ClassVar[tuple[Any, ...]] = (typing.Concatenate,)
     parts: list[NodeLike[N]]
 
     def emit(self) -> TypeExpr:
-        return typing.Concatenate[tuple(part.emit() for part in self.parts)]
+        return self._apply_modifiers(typing.Concatenate[tuple(part.emit() for part in self.parts)])
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "ConcatenateNode[N]":
@@ -546,10 +494,12 @@ class CallableNode(Generic[N], ContainerNode[N]):
 
     def emit(self) -> TypeExpr:
         if self.args is None:
-            return typing.Callable[..., self.return_type.emit()]
-        if isinstance(self.args, list):
-            return typing.Callable[[a.emit() for a in self.args], self.return_type.emit()]
-        return typing.Callable[self.args.emit(), self.return_type.emit()]
+            t = typing.Callable[..., self.return_type.emit()]
+        elif isinstance(self.args, list):
+            t = typing.Callable[[a.emit() for a in self.args], self.return_type.emit()]
+        else:
+            t = typing.Callable[self.args.emit(), self.return_type.emit()]
+        return self._apply_modifiers(t)
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "CallableNode[N]":
@@ -578,7 +528,7 @@ class UnionNode(Generic[*Ctx], ContainerNode[typing.Union[*Ctx]]):
     options: tuple[BaseNode, ...]
 
     def emit(self) -> TypeExpr:
-        return Union[tuple(opt.emit() for opt in self.options)]
+        return self._apply_modifiers(Union[tuple(opt.emit() for opt in self.options)])
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "UnionNode[*Ctx]":
@@ -593,7 +543,7 @@ class UnpackNode(SpecialFormNode):
     target: TupleNode | TypedDictNode | AtomNode | VarNode
 
     def emit(self) -> TypeExpr:
-        return typing.Unpack[self.target.emit()]
+        return self._apply_modifiers(typing.Unpack[self.target.emit()])
 
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> "UnpackNode":
@@ -629,6 +579,11 @@ def _parse_no_origin_type(typ: Any) -> BaseNode:
         return VarNode(typ)
     if isinstance(typ, TypeAliasType):
         return parse_type(typ.__value__)
+    if typ in {typing.Required, typing.NotRequired}:
+        raise InvalidTypeError(
+            f"{typ.__qualname__} requires a single argument",
+            hint=f"Use {typ.__qualname__}[T] with a type argument",
+        )
     node_cls = BaseNode._registry.get(typ)
     if node_cls is not None:
         if node_cls is TupleNode:
@@ -652,6 +607,45 @@ def _parse_no_origin_type(typ: Any) -> BaseNode:
 
 
 def _parse_origin_type(origin: Any, args: tuple[Any, ...], raw: Any) -> BaseNode:
+    if origin is typing.Annotated:
+        if not args:
+            raise InvalidTypeError(
+                "Annotated requires a base type",
+                hint="Annotated[T, ...] must start with a type",
+            )
+        if len(args) < 2:
+            raise InvalidTypeError(
+                f"Annotated requires a type and at least one annotation: {args}",
+                hint="Use Annotated[T, ...] with at least one metadata value",
+            )
+        base = parse_type(args[0])
+        return dataclasses.replace(
+            base, annotated_metadata=base.annotated_metadata + list(args[1:])
+        )
+    if origin is typing.Final:
+        if len(args) != 1:
+            raise InvalidTypeError(
+                f"Final requires a single argument: {args}",
+                hint="Final[T] expects exactly one argument",
+            )
+        inner = parse_type(args[0])
+        return dataclasses.replace(inner, is_final=True)
+    if origin is typing.Required:
+        if len(args) != 1:
+            raise InvalidTypeError(
+                f"Required requires a single argument: {args}",
+                hint="Required[T] expects exactly one argument",
+            )
+        inner = parse_type(args[0])
+        return dataclasses.replace(inner, is_required=True)
+    if origin is typing.NotRequired:
+        if len(args) != 1:
+            raise InvalidTypeError(
+                f"NotRequired requires a single argument: {args}",
+                hint="NotRequired[T] expects exactly one argument",
+            )
+        inner = parse_type(args[0])
+        return dataclasses.replace(inner, is_required=False)
     node_cls = BaseNode._registry.get(origin)
     if node_cls is not None:
         return node_cls.for_args(args)
@@ -734,7 +728,11 @@ def parse_type_expr(typ: Any, *, strict: bool | None = None) -> TypeExprNode:
 def _reject_special(node: BaseNode) -> None:
     """Recursively reject special-form or in-class nodes."""
 
-    if isinstance(node, (SpecialFormNode, InClassExprNode)):
+    if (
+        isinstance(node, (SpecialFormNode, InClassExprNode))
+        or node.is_final
+        or node.is_required is not None
+    ):
         raise InvalidTypeError(
             "Special form not allowed in this context",
             hint="Use this type only in valid contexts",
@@ -873,11 +871,11 @@ def _format_runtime_type(type_obj: Any) -> TypeRenderInfo:
 
     if origin is typing.Annotated:
         node = parse_type(type_obj)
-        assert isinstance(node, AnnotatedNode)
-        base_fmt = format_type(node.base.emit())
+        base_node = dataclasses.replace(node, annotated_metadata=[])
+        base_fmt = format_type(base_node.emit())
         used.add(typing.Annotated)
         used.update(base_fmt.used)
-        metadata_str = ", ".join(repr(m) for m in node.metadata)
+        metadata_str = ", ".join(repr(m) for m in node.annotated_metadata)
         return TypeRenderInfo(f"Annotated[{base_fmt.text}, {metadata_str}]", used)
 
     if origin is typing.Literal:

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -137,6 +137,8 @@ TYPED_LAMBDA: Callable[[int, int], int] = lambda a, b: a + b
 ANNOTATED_EXTRA: Annotated[str, "extra"] = "x"
 # Nested Annotated usage should merge metadata
 NESTED_ANNOTATED: Annotated[Annotated[int, "a"], "b"] = 3
+# Annotated union to ensure metadata is preserved with unions
+ANNOTATED_OPTIONAL_META: Annotated[int | None, "meta"] = 0
 
 # Built-in generic without dedicated handler
 GENERIC_DEQUE: Deque[int]

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -88,6 +88,8 @@ ANNOTATED_EXTRA: Annotated[str, 'extra']
 
 NESTED_ANNOTATED: Annotated[int, 'a', 'b']
 
+ANNOTATED_OPTIONAL_META: Annotated[int | None, 'meta']
+
 class UserBox[T]: ...
 
 class Basic:


### PR DESCRIPTION
## Summary
- store Final/Required/Annotated modifiers as flags on BaseNode
- parse Final, Required, NotRequired and Annotated into node metadata
- broaden tests for modifier handling and unions
- represent bare Final with a dedicated FinalNode instead of `Final[Any]`
- regenerate annotation stubs for updated import ordering

## Testing
- `ruff check --fix macrotype/types_ast.py tests/types_ast_test.py tests/annotations.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68966ba5158883299fab683a40d3fd2b