### PR TITLE
refactor: support union sets in ListNode

### DIFF
--- a/__macrotype__/macrotype/types_ast.pyi
+++ b/__macrotype__/macrotype/types_ast.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype macrotype -o __macrotype__/macrotype
+# Generated via: macrotype macrotype/types_ast.py
 # Do not edit by hand
 from typing import Any, Callable, ClassVar, ParamSpec, TypeVar, TypeVarTuple, Unpack, _TypedDictMeta
 from dataclasses import dataclass
@@ -10,7 +10,7 @@ class InvalidTypeError(TypeError):
     def __init__(self, message: str, *, hint: str | None, file: str | None, line: int | None) -> None: ...
     def __str__(self) -> str: ...
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(eq=False, frozen=True, kw_only=True)
 class BaseNode:
     annotated_metadata: list[Any]
     is_final: bool
@@ -21,14 +21,16 @@ class BaseNode:
     def __init_subclass__(cls, **kwargs: Any) -> None: ...
     def emit(self) -> Any: ...
     def _apply_modifiers(self, t: Any) -> Any: ...
+    def __hash__(self) -> int: ...
+    def __eq__(self, other: object) -> bool: ...
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(eq=False, frozen=True, kw_only=True)
 class TypeExprNode(BaseNode): ...
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(eq=False, frozen=True, kw_only=True)
 class InClassExprNode(BaseNode): ...
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(eq=False, frozen=True, kw_only=True)
 class SpecialFormNode(BaseNode): ...
 
 N = TypeVar('N')
@@ -39,42 +41,44 @@ V = TypeVar('V')
 
 Ctx = TypeVarTuple('Ctx')
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(eq=False, frozen=True, kw_only=True)
 class ContainerNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](BaseNode): ...
 
 type NodeLike[N] = N | ContainerNode[N]
 
-@dataclass(frozen=True)
+def emit_slot(alts: frozenset[BaseNode]) -> Any: ...
+
+@dataclass(eq=False, frozen=True)
 class AtomNode(TypeExprNode):
     type_: Any
     def emit(self) -> Any: ...
     @staticmethod
     def is_atom(type_: Any) -> bool: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class VarNode(TypeExprNode):
     var: TypeVar | ParamSpec | TypeVarTuple
     def emit(self) -> Any: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class TypedDictNode(AtomNode):
     type_: _TypedDictMeta
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class GenericNode(ContainerNode[TypeExprNode]):
     origin: type[Any]
     args: tuple[BaseNode, ...]
     def emit(self) -> Any: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class LiteralNode(TypeExprNode):
     handles: ClassVar[tuple[Any, ...]]
-    values: list[int | str | bool | Enum | None]
+    values: list[str | None | Enum | int | bool]
     def emit(self) -> Any: ...
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> LiteralNode: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class DictNode[K: (TypeExprNode, InClassExprNode | TypeExprNode), V: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[K | V]):
     handles: ClassVar[tuple[Any, ...]]
     key: NodeLike[K]
@@ -83,16 +87,16 @@ class DictNode[K: (TypeExprNode, InClassExprNode | TypeExprNode), V: (TypeExprNo
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> BaseNode: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class ListNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N]):
     handles: ClassVar[tuple[Any, ...]]
-    element: NodeLike[N]
+    element: frozenset[BaseNode]
     container_type: ClassVar[type]
     def emit(self) -> Any: ...
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> BaseNode: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class TupleNode[*Ctx](ContainerNode[Unpack[Ctx]]):
     handles: ClassVar[tuple[Any, ...]]
     items: tuple[BaseNode, ...]
@@ -101,7 +105,7 @@ class TupleNode[*Ctx](ContainerNode[Unpack[Ctx]]):
     @classmethod
     def for_args[N](cls, args: tuple[Any, ...]) -> TupleNode[N]: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class SetNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N]):
     handles: ClassVar[tuple[Any, ...]]
     element: NodeLike[N]
@@ -110,7 +114,7 @@ class SetNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> BaseNode: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class FrozenSetNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N]):
     handles: ClassVar[tuple[Any, ...]]
     element: NodeLike[N]
@@ -119,7 +123,7 @@ class FrozenSetNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](Container
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> BaseNode: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class InitVarNode(SpecialFormNode):
     handles: ClassVar[tuple[Any, ...]]
     inner: TypeExprNode
@@ -127,21 +131,21 @@ class InitVarNode(SpecialFormNode):
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> InitVarNode: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class SelfNode(InClassExprNode):
     handles: ClassVar[tuple[Any, ...]]
     def emit(self) -> Any: ...
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> SelfNode: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class FinalNode(SpecialFormNode):
     handles: ClassVar[tuple[Any, ...]]
     def emit(self) -> Any: ...
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> FinalNode: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class ClassVarNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N], InClassExprNode):
     handles: ClassVar[tuple[Any, ...]]
     inner: NodeLike[N]
@@ -149,7 +153,7 @@ class ClassVarNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerN
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> ClassVarNode[N]: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class TypeGuardNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N], SpecialFormNode):
     handles: ClassVar[tuple[Any, ...]]
     target: NodeLike[N]
@@ -157,7 +161,7 @@ class TypeGuardNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](Container
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> TypeGuardNode[N]: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class ConcatenateNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N]):
     handles: ClassVar[tuple[Any, ...]]
     parts: list[NodeLike[N]]
@@ -165,7 +169,7 @@ class ConcatenateNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](Contain
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> ConcatenateNode[N]: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class CallableNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerNode[N]):
     handles: ClassVar[tuple[Any, ...]]
     args: NodeLike[N] | list[NodeLike[N]] | None
@@ -174,7 +178,7 @@ class CallableNode[N: (TypeExprNode, InClassExprNode | TypeExprNode)](ContainerN
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> CallableNode[N]: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class UnionNode[*Ctx](ContainerNode[Unpack[Ctx]]):
     handles: ClassVar[tuple[Any, ...]]
     options: tuple[BaseNode, ...]
@@ -182,7 +186,7 @@ class UnionNode[*Ctx](ContainerNode[Unpack[Ctx]]):
     @classmethod
     def for_args(cls, args: tuple[Any, ...]) -> UnionNode[Unpack[Ctx]]: ...
 
-@dataclass(frozen=True)
+@dataclass(eq=False, frozen=True)
 class UnpackNode(SpecialFormNode):
     handles: ClassVar[tuple[Any, ...]]
     target: TupleNode | TypedDictNode | AtomNode | VarNode

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@ can customize the result by providing an ``on_generic`` callback::
 
     def handle(node: GenericNode):
         if node.origin is deque:
-            return ListNode(node.args[0])
+            return ListNode(frozenset({node.args[0]}))
         return node
 
     parse_type(Deque[int], on_generic=handle)

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -557,6 +557,11 @@ DICT_WITH_IMPLICIT_ANY: dict[int]  # type: ignore[type-arg]  # pyright: ignore[r
 # Generic container without type arguments should remain unparameterized
 UNPARAM_LIST: list
 
+# Lists exercising set-based element slots
+LIST_INT_ONLY: list[int]
+LIST_INT_OR_STR: list[int | str]
+LIST_NESTED_UNION: list[int | (str | None)]
+
 
 # Edge case: positional-only and keyword-only parameters
 def pos_only_func(a: int, b: str, /) -> None:

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype tests/annotations.py -o -
+# Generated via: macrotype tests/annotations.py -o tests/annotations.pyi
 # Do not edit by hand
 # pyright: basic
 from typing import Annotated, Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NoReturn, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload, override, runtime_checkable
@@ -544,3 +544,9 @@ LITERAL_STR_VAR: LiteralString
 DICT_WITH_IMPLICIT_ANY: dict[int]  # type: ignore[type-arg]  # pyright: ignore[reportInvalidTypeArguments]
 
 UNPARAM_LIST: list
+
+LIST_INT_ONLY: list[int]
+
+LIST_INT_OR_STR: list[int | str]
+
+LIST_NESTED_UNION: list[int | None | str]

--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -67,9 +67,16 @@ PARSINGS = {
     dict[int, str]: DictNode(AtomNode(int), AtomNode(str)),
     dict[int, typing.Any]: DictNode(AtomNode(int), AtomNode(typing.Any)),
     list[()]: AtomNode(list),
-    list[int]: ListNode(AtomNode(int)),
-    list[list[int]]: ListNode(ListNode(AtomNode(int))),
-    dict[str, list[int]]: DictNode(AtomNode(str), ListNode(AtomNode(int))),
+    list[int]: ListNode(frozenset({AtomNode(int)})),
+    list[int | str]: ListNode(frozenset({AtomNode(int), AtomNode(str)})),
+    list[int | (str | None)]: ListNode(
+        frozenset({AtomNode(int), AtomNode(str), AtomNode(type(None))})
+    ),
+    list[list[int]]: ListNode(frozenset({ListNode(frozenset({AtomNode(int)}))})),
+    dict[str, list[int]]: DictNode(
+        AtomNode(str),
+        ListNode(frozenset({AtomNode(int)})),
+    ),
     tuple[()]: TupleNode((), False),
     tuple[int]: TupleNode((AtomNode(int),), True),
     tuple[int, str]: TupleNode((AtomNode(int), AtomNode(str)), False),
@@ -111,7 +118,7 @@ PARSINGS = {
     P: VarNode(P),
     Ts: VarNode(Ts),
     typing.Unpack[Ts]: UnpackNode(VarNode(Ts)),
-    AliasListT: ListNode(VarNode(T)),
+    AliasListT: ListNode(frozenset({VarNode(T)})),
     typing.Concatenate[int, P]: ConcatenateNode([AtomNode(int), VarNode(P)]),
     typing.Callable[P, int]: CallableNode(VarNode(P), AtomNode(int)),
     typing.Callable[typing.Concatenate[int, P], int]: CallableNode(

--- a/tests/types_ast_typing.py
+++ b/tests/types_ast_typing.py
@@ -3,6 +3,7 @@ from typing import assert_type
 
 from macrotype.types_ast import (
     AtomNode,
+    BaseNode,
     ClassVarNode,
     InClassExprNode,
     ListNode,
@@ -12,10 +13,10 @@ from macrotype.types_ast import (
 )
 
 expr_node: NodeLike[TypeExprNode] = AtomNode(int)
-expr_node = ListNode(AtomNode(int))
+expr_node = ListNode(frozenset({AtomNode(int)}))
 
 class_node: NodeLike[InClassExprNode | TypeExprNode] = ClassVarNode(AtomNode(int))
 class_node = SelfNode()
 
-ln = ListNode(AtomNode(int))
-assert_type(ln.element, NodeLike[TypeExprNode])
+ln = ListNode(frozenset({AtomNode(int)}))
+assert_type(ln.element, frozenset[BaseNode])


### PR DESCRIPTION
## Summary
- support frozenset-based element alternatives in `ListNode`
- add `emit_slot` helper and hashing for nodes
- test list unions and bare generics via annotations

## Testing
- `ruff format`
- `ruff check --fix`
- `pytest tests/types_ast_test.py::test_parsing_roundtrip tests/test_all.py::test_stub_generation_matches_expected tests/test_all.py::test_process_file tests/test_all.py::test_process_directory -q`

------
https://chatgpt.com/codex/tasks/task_e_68968c24897c8329b8c0c79104294527