### PR TITLE
refactor: rename node annotation field

### DIFF
--- a/__macrotype__/macrotype/types_ast.pyi
+++ b/__macrotype__/macrotype/types_ast.pyi
@@ -12,7 +12,7 @@ class InvalidTypeError(TypeError):
 
 @dataclass(frozen=True, kw_only=True)
 class BaseNode:
-    annotated_metadata: list[Any]
+    node_ann: tuple[Any, ...]
     is_final: bool
     is_required: bool | None
     _registry: ClassVar[dict[Any, type[BaseNode]]]

--- a/macrotype/stubgen.py
+++ b/macrotype/stubgen.py
@@ -168,14 +168,14 @@ def load_module_from_path(
 
     if name in sys.modules:
         module = sys.modules[name]
-        if getattr(module, "__file__", None) and not hasattr(
-            module, "__macrotype_header_pragmas__"
-        ):
-            header, comments, lines = _extract_source_info(Path(module.__file__).read_text())
-            module.__macrotype_header_pragmas__ = header
-            module.__macrotype_comments__ = comments
-            module.__macrotype_line_map__ = lines
-        return module
+        if getattr(module, "__file__", None) and Path(module.__file__).resolve() == path.resolve():
+            if not hasattr(module, "__macrotype_header_pragmas__"):
+                header, comments, lines = _extract_source_info(Path(module.__file__).read_text())
+                module.__macrotype_header_pragmas__ = header
+                module.__macrotype_comments__ = comments
+                module.__macrotype_line_map__ = lines
+            return module
+        del sys.modules[name]
 
     if not type_checking:
         spec = importlib.util.spec_from_file_location(name, path)

--- a/tests/types_ast_test.py
+++ b/tests/types_ast_test.py
@@ -90,7 +90,7 @@ PARSINGS = {
     ),
     typing.Callable[[int, str], bool]: CallableNode([AtomNode(int), AtomNode(str)], AtomNode(bool)),
     typing.Callable[..., int]: CallableNode(None, AtomNode(int)),
-    typing.Annotated[int, "x"]: AtomNode(int, annotated_metadata=["x"]),
+    typing.Annotated[int, "x"]: AtomNode(int, node_ann=("x",)),
     dataclasses.InitVar: InitVarNode(AtomNode(typing.Any)),
     dataclasses.InitVar[int]: InitVarNode(AtomNode(int)),
     typing.Self: SelfNode(),
@@ -203,14 +203,14 @@ def test_typeguard_special_form() -> None:
 
 def test_annotated_nesting() -> None:
     nested = typing.Annotated[typing.Annotated[int, "a"], "b"]
-    expected = AtomNode(int, annotated_metadata=["a", "b"])
+    expected = AtomNode(int, node_ann=("a", "b"))
     assert parse_type(nested) == expected
     assert parse_type_expr(nested) == expected
 
 
 def test_annotated_classvar() -> None:
     ann = typing.Annotated[typing.ClassVar[int], "x"]
-    assert parse_type(ann) == ClassVarNode(AtomNode(int), annotated_metadata=["x"])
+    assert parse_type(ann) == ClassVarNode(AtomNode(int), node_ann=("x",))
     with pytest.raises(TypeError):
         parse_type_expr(ann)
 


### PR DESCRIPTION
## Summary
- use `node_ann` tuple on BaseNode to store per-alternative annotations
- ensure `load_module_from_path` reloads modules when paths differ

## Testing
- `ruff format macrotype/types_ast.py tests/types_ast_test.py`
- `ruff check --fix macrotype/stubgen.py macrotype/types_ast.py tests/types_ast_test.py`
- `pytest`
- `pytest tests/test_dogfood.py::test_cli_self tests/test_invalid_typing.py::test_forward_ref_raises_error`


------
https://chatgpt.com/codex/tasks/task_e_68969b7b10308329a61cec7f12435a11