### PR TITLE
Skip stdlib dogfood test to avoid side effects

### DIFF
--- a/tests/test_dogfood.py
+++ b/tests/test_dogfood.py
@@ -4,6 +4,9 @@ import sys
 import sysconfig
 from pathlib import Path
 
+# Test helpers
+import pytest
+
 # Ensure package root on path when running tests directly
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -74,6 +77,7 @@ def test_cli_requires_relative_path(tmp_path: Path) -> None:
     assert "specify -o" in result.stderr
 
 
+@pytest.mark.skip(reason="imports entire stdlib which may trigger side effects")
 def test_cli_stdlib(tmp_path: Path) -> None:
     repo_root = STUBS_DIR.parents[1]
     stdlib = Path(sysconfig.get_path("stdlib"))


### PR DESCRIPTION
## Summary
- skip `test_cli_stdlib` which imports the entire standard library and can trigger side effects such as opening browsers
- add pytest import for new skip decorator

## Testing
- `ruff format tests/test_dogfood.py`
- `ruff check --fix tests/test_dogfood.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689af390ab448329a0f77237efcf5148