### PR TITLE
Return ModuleInfo from scan_module

### DIFF
--- a/__macrotype__/macrotype/scanner.pyi
+++ b/__macrotype__/macrotype/scanner.pyi
@@ -1,0 +1,30 @@
+# Generated via: macrotype macrotype/scanner.py -o __macrotype__/macrotype/scanner.pyi
+# Do not edit by hand
+from collections.abc import Mapping
+from dataclasses import dataclass
+from macrotype.types_ir import ClassSymbol, FuncSymbol, Provenance, Symbol
+from typing import Any, Callable
+
+ModuleType = module
+
+@dataclass
+class ModuleInfo:
+    mod: module
+    symbols: list[Symbol]
+    provenance: str
+
+def _is_dunder(name: str) -> bool: ...
+
+def _source_prov(obj: Any, *, modname: str, key: str, name: str) -> Provenance: ...
+
+def _mk_key(parent_key: None | str, modname: str, name: str) -> str: ...
+
+def _get_modname(glb_or_mod: Mapping[str, Any] | module) -> str: ...
+
+def _get_globals(glb_or_mod: Mapping[str, Any] | module) -> dict[str, Any]: ...
+
+def scan_module(glb_or_mod: Mapping[str, Any] | module) -> ModuleInfo: ...
+
+def _scan_function(fn: Callable[..., Any], *, modname: str, parent_key: None | str) -> FuncSymbol: ...
+
+def _scan_class(cls: type, *, modname: str, parent_key: None | str) -> ClassSymbol: ...

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -4,7 +4,7 @@ import importlib
 
 import pytest
 
-from macrotype.scanner import scan_module
+from macrotype.scanner import ModuleInfo, scan_module
 from macrotype.types_ir import AliasSymbol, ClassSymbol, FuncSymbol, Site, Symbol, VarSymbol
 
 # ---- normalize to stable “shapes” (ignores file/line etc.) ----
@@ -63,7 +63,11 @@ def sym_shape(sym: Symbol) -> dict:
 @pytest.fixture(scope="module")
 def idx():
     ann = importlib.import_module("tests.annotations")  # your big fixture module
-    shapes = [sym_shape(s) for s in scan_module(ann)]
+    mi = scan_module(ann)
+    assert isinstance(mi, ModuleInfo)
+    assert mi.mod is ann
+    assert mi.provenance == "tests.annotations"
+    shapes = [sym_shape(s) for s in mi.symbols]
     # index by key and name for convenience
     by_key = {s["key"]: s for s in shapes}
     by_name = {}


### PR DESCRIPTION
## Summary
- Wrap module scans in a ModuleInfo dataclass carrying the original module, collected symbols, and provenance
- Adjust scanner tests to validate ModuleInfo fields and use new API
- Add generated stub for the scanner module

## Testing
- `ruff format macrotype/scanner.py tests/test_scanner.py`
- `ruff check macrotype/scanner.py tests/test_scanner.py --fix`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689afcb31fd083299e6a7bf39e815647