### PR TITLE
Add module emitter for generating .pyi lines

### DIFF
--- a/macrotype/emit_module.py
+++ b/macrotype/emit_module.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from .emit_type import EmitCtx, emit_type
+from .scanner import ModuleInfo
+from .types_ir import AliasSymbol, ClassSymbol, FuncSymbol, Symbol, VarSymbol
+
+INDENT = "    "
+
+
+def emit_module(mi: ModuleInfo) -> list[str]:
+    """Format *mi* into ``.pyi`` lines.
+
+    This is a light wrapper around :func:`emit_type` that walks the ``ModuleInfo``
+    tree and formats each symbol.  It is intentionally dumb: no validation or
+    reordering occurs here; we simply preserve the structure that earlier passes
+    produced while collecting required ``typing`` imports via :class:`EmitCtx`.
+    """
+
+    ctx = EmitCtx()
+    body: list[str] = []
+    for sym in mi.symbols:
+        body.extend(_emit_symbol(sym, ctx, indent=0))
+        body.append("")
+    if body and body[-1] == "":
+        body.pop()
+
+    pre: list[str] = []
+    if ctx.typing_needed:
+        names = ", ".join(sorted(ctx.typing_needed))
+        pre.append(f"from typing import {names}")
+        if body:
+            pre.append("")
+    return pre + body
+
+
+def _emit_symbol(sym: Symbol, ctx: EmitCtx, *, indent: int) -> list[str]:
+    pad = INDENT * indent
+    match sym:
+        case VarSymbol(site=site):
+            ty = emit_type(site.validated, ctx)
+            return [f"{pad}{sym.name}: {ty}"]
+        case AliasSymbol(value=site):
+            ty = emit_type(site.validated, ctx)
+            return [f"{pad}type {sym.name} = {ty}"]
+        case FuncSymbol(params=params, ret=ret, decorators=decos):
+            pieces: list[str] = []
+            for d in decos:
+                pieces.append(f"{pad}@{d}")
+            params_s: list[str] = []
+            for p in params:
+                ann = emit_type(p.validated, ctx)
+                params_s.append(f"{p.name}: {ann}")
+            param_str = ", ".join(params_s)
+            ret_str = f" -> {emit_type(ret.validated, ctx)}" if ret else ""
+            pieces.append(f"{pad}def {sym.name}({param_str}){ret_str}: ...")
+            return pieces
+        case ClassSymbol(bases=bases, td_fields=fields, members=members):
+            base_str = ""
+            if bases:
+                base_str = f"({', '.join(emit_type(b.validated, ctx) for b in bases)})"
+            lines = [f"{pad}class {sym.name}{base_str}:"]
+            if fields:
+                for f in fields:
+                    ty = emit_type(f.validated, ctx)
+                    lines.append(f"{pad}{INDENT}{f.name}: {ty}")
+            if members:
+                for m in members:
+                    lines.extend(_emit_symbol(m, ctx, indent=indent + 1))
+            if not fields and not members:
+                lines.append(f"{pad}{INDENT}...")
+            return lines
+        case _:
+            raise NotImplementedError(f"Unsupported symbol: {type(sym).__name__}")

--- a/tests/test_emit_module.py
+++ b/tests/test_emit_module.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from types import ModuleType
+
+from macrotype.emit_module import emit_module
+from macrotype.scanner import ModuleInfo
+from macrotype.types_ir import (
+    AliasSymbol,
+    ClassSymbol,
+    FuncSymbol,
+    Site,
+    TyAny,
+    TyApp,
+    TyClassVar,
+    TyName,
+    ValidatedTy,
+    VarSymbol,
+)
+
+
+def b(name: str) -> TyName:  # builtins helper
+    return TyName(module="builtins", name=name)
+
+
+def vt(t) -> ValidatedTy:
+    return ValidatedTy(t)
+
+
+# ---- table: ModuleInfo -> emitted lines ----
+mod1 = ModuleType("m1")
+case1 = (
+    ModuleInfo(
+        mod=mod1,
+        provenance="m1",
+        symbols=[
+            VarSymbol(name="x", key="m1.x", site=Site(role="var", raw=None, validated=vt(TyAny()))),
+        ],
+    ),
+    ["from typing import Any", "", "x: Any"],
+)
+
+mod2 = ModuleType("m2")
+case2 = (
+    ModuleInfo(
+        mod=mod2,
+        provenance="m2",
+        symbols=[
+            VarSymbol(name="v", key="m2.v", site=Site(role="var", raw=None, validated=vt(TyAny()))),
+            AliasSymbol(
+                name="Alias",
+                key="m2.Alias",
+                value=Site(
+                    role="alias_value",
+                    raw=None,
+                    validated=vt(TyApp(base=b("list"), args=(b("int"),))),
+                ),
+            ),
+            FuncSymbol(
+                name="f",
+                key="m2.f",
+                params=(Site(role="param", name="x", raw=None, validated=vt(b("int"))),),
+                ret=Site(role="return", raw=None, validated=vt(b("str"))),
+            ),
+            ClassSymbol(
+                name="C",
+                key="m2.C",
+                bases=(),
+                members=(
+                    VarSymbol(
+                        name="y",
+                        key="m2.C.y",
+                        site=Site(
+                            role="var",
+                            name="y",
+                            raw=None,
+                            validated=vt(TyClassVar(inner=b("int"))),
+                        ),
+                    ),
+                ),
+            ),
+        ],
+    ),
+    [
+        "from typing import Any, ClassVar",
+        "",
+        "v: Any",
+        "",
+        "type Alias = list[int]",
+        "",
+        "def f(x: int) -> str: ...",
+        "",
+        "class C:",
+        "    y: ClassVar[int]",
+    ],
+)
+
+CASES = [case1, case2]
+
+
+def test_emit_module_table() -> None:
+    got = [emit_module(mi) for mi, _ in CASES]
+    expected = [exp for _, exp in CASES]
+    assert got == expected


### PR DESCRIPTION
## Summary
- implement `emit_module` to format `ModuleInfo` symbols into `.pyi` lines and collect required `typing` imports
- add table-driven tests for module emission covering variables, aliases, functions, and classes

## Testing
- `ruff format macrotype/emit_module.py tests/test_emit_module.py`
- `ruff check macrotype/emit_module.py tests/test_emit_module.py --fix`
- `pytest tests/test_emit_module.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689affcaf6548329b8c29636f6b3ca4d