### PR TITLE
Switch tuple types to TyApp

### DIFF
--- a/__macrotype__/macrotype/normalize.pyi
+++ b/__macrotype__/macrotype/normalize.pyi
@@ -1,7 +1,7 @@
 # Generated via: macrotype macrotype
 # Do not edit by hand
 from dataclasses import dataclass
-from macrotype.types.ir import NormalizedTy, ResolvedTy, Ty
+from macrotype.types.ir import Ty
 
 @dataclass(frozen=True)
 class NormOpts:

--- a/__macrotype__/macrotype/resolve.pyi
+++ b/__macrotype__/macrotype/resolve.pyi
@@ -1,7 +1,7 @@
 # Generated via: macrotype macrotype
 # Do not edit by hand
 from dataclasses import dataclass
-from macrotype.types.ir import ParsedTy, ResolvedTy, Ty
+from macrotype.types.ir import Ty
 
 @dataclass(frozen=True)
 class ResolveEnv:

--- a/__macrotype__/macrotype/validate.pyi
+++ b/__macrotype__/macrotype/validate.pyi
@@ -1,7 +1,7 @@
 # Generated via: macrotype macrotype
 # Do not edit by hand
-from macrotype.types.ir import NormalizedTy, Ty, TyApp, TyRoot
-from typing import Literal
+from macrotype.types.ir import Ty, TyApp, TyRoot
+from typing import Literal, Literal
 
 class TypeValidationError(TypeError): ...
 

--- a/macrotype/types/emit.py
+++ b/macrotype/types/emit.py
@@ -13,7 +13,6 @@ from .ir import (
     TyNever,
     TyParamSpec,
     TyRoot,
-    TyTuple,
     TyTypeVar,
     TyTypeVarTuple,
     TyUnion,
@@ -103,11 +102,8 @@ def _emit_no_annos(n: Ty, ctx: EmitCtx) -> str:
             return " | ".join(_emit(o, ctx) for o in opts)
 
         case TyApp(base=base, args=args):
-            # tuple variadic printed as 'tuple[T, ...]' by virtue of Ellipsis name
+            # tuple variadic printed as 'tuple[T, Ellipsis]' via Ellipsis name
             return f"{_emit(base, ctx)}[{', '.join(_emit(a, ctx) for a in args)}]"
-
-        case TyTuple(items=items):
-            return f"tuple[{', '.join(_emit(i, ctx) for i in items)}]"
 
         case TyLiteral(values=vals):
             ctx.need("Literal")

--- a/macrotype/types/ir.py
+++ b/macrotype/types/ir.py
@@ -82,19 +82,6 @@ class TyApp(Ty):
 
 
 @dataclass(frozen=True, kw_only=True)
-class TyTuple(Ty):
-    """
-    Tuple type (fixed-length). Variadic `tuple[T, ...]` is modeled as
-    `TyApp(TyName("builtins","tuple"), (T, TyName("builtins","Ellipsis"))).`
-
-    Examples:
-      - `tuple[int, str]`
-    """
-
-    items: tuple[Ty, ...]
-
-
-@dataclass(frozen=True, kw_only=True)
 class TyUnion(Ty):
     """
     Union type (already canonicalized in normalization).

--- a/macrotype/types/normalize.py
+++ b/macrotype/types/normalize.py
@@ -13,7 +13,6 @@ from .ir import (
     TyName,
     TyNever,
     TyRoot,
-    TyTuple,
     TyUnion,
     TyUnpack,
 )
@@ -81,9 +80,6 @@ def _norm(n: Ty, o: NormOpts) -> Ty:
             args_r = tuple(_norm(a, o) for a in args)
             # Variadic tuple canonical shape: base must be builtins.tuple, last arg Ellipsis => leave as-is
             res = TyApp(base=base_r, args=args_r)
-
-        case TyTuple(items=items):
-            res = TyTuple(items=tuple(_norm(a, o) for a in items))
 
         case TyUnion(options=opts):
             # flatten

--- a/macrotype/types/parse.py
+++ b/macrotype/types/parse.py
@@ -21,7 +21,6 @@ from .ir import (
     TyNever,
     TyParamSpec,
     TyRoot,
-    TyTuple,
     TyTypeVar,
     TyTypeVarTuple,
     TyUnion,
@@ -146,12 +145,10 @@ def _to_ir(tp: object, env: ParseEnv) -> Ty:
         return TyLiteral(values=tuple(_litval_of(a) for a in args))
 
     if origin is tuple:
-        if args and args[-1] is Ellipsis:
-            items = tuple(_to_ir(a, env) for a in args[:-1]) + (
-                TyName(module="builtins", name="Ellipsis"),
-            )
-            return TyApp(base=TyName(module="builtins", name="tuple"), args=items)
-        return TyTuple(items=tuple(_to_ir(a, env) for a in args))
+        return TyApp(
+            base=TyName(module="builtins", name="tuple"),
+            args=tuple(_to_ir(a, env) for a in args),
+        )
 
     if origin in (t.Callable, abc.Callable):
         if args and args[0] is Ellipsis:
@@ -226,7 +223,7 @@ def parse_root(tp: object, env: Optional[ParseEnv] = None) -> TyRoot:
             obj = _missing
         else:
             break
-    
+
     ty = _to_ir(obj, env) if obj is not _missing else None
     return TyRoot(
         ty=ty,

--- a/macrotype/types/resolve.py
+++ b/macrotype/types/resolve.py
@@ -15,7 +15,6 @@ from .ir import (
     TyNever,
     TyParamSpec,
     TyRoot,
-    TyTuple,
     TyTypeVar,
     TyTypeVarTuple,
     TyUnion,
@@ -89,9 +88,6 @@ def _res(node: Ty, env: ResolveEnv) -> Ty:
             if isinstance(base_r, TyName) and base_r.module == "typing" and base_r.name == "Type":
                 base_r = TyName(module="builtins", name="type")
             res = TyApp(base=base_r, args=args_r)
-
-        case TyTuple(items=items):
-            res = TyTuple(items=tuple(_res(a, env) for a in items))
 
         case TyUnion(options=opts):
             res = TyUnion(options=tuple(_res(a, env) for a in opts))

--- a/macrotype/types/validate.py
+++ b/macrotype/types/validate.py
@@ -13,7 +13,6 @@ from .ir import (
     TyNever,
     TyParamSpec,
     TyRoot,
-    TyTuple,
     TyTypeVar,
     TyTypeVarTuple,
     TyUnion,
@@ -56,16 +55,8 @@ def _v(node: Ty, *, ctx: Context) -> None:
                 _validate_literal_value(v)
             return
 
-        # Tuple (fixed-length)
-        case TyTuple(items=items):
-            for it in items:
-                _v(it, ctx="tuple_items")
-            return
-
-        # tuple[T, ...] (variadic) or tuple[T1, ..., Tk, ...]
+        # tuple[...] forms (fixed-length or variadic)
         case TyApp(base=TyName(module="builtins", name="tuple"), args=args):
-            if not args:
-                raise TypeValidationError("tuple[...] must have at least one argument")
             # Ellipsis, if present, must be last; only one allowed
             ell_count = sum(
                 1

--- a/tests/types/test_normalize.py
+++ b/tests/types/test_normalize.py
@@ -7,7 +7,6 @@ from macrotype.types.ir import (
     TyLiteral,
     TyName,
     TyRoot,
-    TyTuple,
     TyUnion,
 )
 from macrotype.types.normalize import norm
@@ -73,12 +72,12 @@ CASES = [
     ),
     # Tuple elements normalized recursively
     (
-        TyTuple(items=(typ("List"),)),
-        TyTuple(items=(b("list"),)),
+        TyApp(base=b("tuple"), args=(typ("List"),)),
+        TyApp(base=b("tuple"), args=(b("list"),)),
     ),
     (
-        TyTuple(items=(TyApp(base=typ("List"), args=(b("int"),)),)),
-        TyTuple(items=(TyApp(base=b("list"), args=(b("int"),)),)),
+        TyApp(base=b("tuple"), args=(TyApp(base=typ("List"), args=(b("int"),)),)),
+        TyApp(base=b("tuple"), args=(TyApp(base=b("list"), args=(b("int"),)),)),
     ),
 ]
 

--- a/tests/types/test_parse.py
+++ b/tests/types/test_parse.py
@@ -17,7 +17,6 @@ from macrotype.types.ir import (
     TyNever,
     TyParamSpec,
     TyRoot,
-    TyTuple,
     TyTypeVar,
     TyTypeVarTuple,
     TyUnion,
@@ -44,7 +43,9 @@ def r(
     classvar: bool = False,
     annotations: TyAnnoTree | None = None,
 ) -> TyRoot:
-    return TyRoot(ty=ty, is_final=final, is_required=required, is_classvar=classvar, annotations=annotations)
+    return TyRoot(
+        ty=ty, is_final=final, is_required=required, is_classvar=classvar, annotations=annotations
+    )
 
 
 # ----- fixtures used in tests -----
@@ -108,9 +109,9 @@ CASES: list[tuple[object, TyRoot]] = [
         ),
     ),
     # tuples
-    (tuple[()], r(TyTuple(items=()))),
-    (tuple[int], r(TyTuple(items=(b("int"),)))),
-    (tuple[int, str], r(TyTuple(items=(b("int"), b("str"))))),
+    (tuple[()], r(TyApp(base=b("tuple"), args=()))),
+    (tuple[int], r(TyApp(base=b("tuple"), args=(b("int"),)))),
+    (tuple[int, str], r(TyApp(base=b("tuple"), args=(b("int"), b("str"))))),
     # variadic as application with Ellipsis marker
     (tuple[int, ...], r(TyApp(base=b("tuple"), args=(b("int"), b("Ellipsis"))))),
     (
@@ -121,7 +122,12 @@ CASES: list[tuple[object, TyRoot]] = [
     (t.Unpack[Ts], r(TyUnpack(inner=TyTypeVarTuple(name="Ts")))),
     (
         tuple[t.Unpack[Ts]],
-        r(TyTuple(items=(TyUnpack(inner=TyTypeVarTuple(name="Ts")),))),
+        r(
+            TyApp(
+                base=b("tuple"),
+                args=(TyUnpack(inner=TyTypeVarTuple(name="Ts")),),
+            )
+        ),
     ),
     # sets
     (set[int], r(TyApp(base=b("set"), args=(b("int"),)))),

--- a/tests/types/test_validate.py
+++ b/tests/types/test_validate.py
@@ -9,7 +9,6 @@ from macrotype.types.ir import (
     TyName,
     TyParamSpec,
     TyRoot,
-    TyTuple,
     TyTypeVarTuple,
     TyUnion,
     TyUnpack,
@@ -30,7 +29,7 @@ GOOD = [
     b("int"),
     TyUnion(options=(b("int"), b("str"))),
     TyLiteral(values=(1, "x", (True, 2))),
-    TyTuple(items=(b("int"), b("str"))),
+    TyApp(base=b("tuple"), args=(b("int"), b("str"))),
     TyApp(base=b("tuple"), args=(b("int"), b("Ellipsis"))),  # tuple[int, ...]
     TyApp(base=b("tuple"), args=(b("int"), b("str"), b("Ellipsis"))),  # tuple[int, str, ...]
     TyCallable(params=..., ret=b("int")),  # Callable[..., int]
@@ -40,7 +39,10 @@ GOOD = [
         params=(TyApp(base=typ("Concatenate"), args=(b("int"), TyParamSpec(name="P"))),),
         ret=b("int"),
     ),  # Callable[Concatenate[int, P], int]
-    TyTuple(items=(TyUnpack(inner=TyTypeVarTuple(name="Ts")),)),  # tuple[Unpack[Ts]]
+    TyApp(
+        base=b("tuple"),
+        args=(TyUnpack(inner=TyTypeVarTuple(name="Ts")),),
+    ),  # tuple[Unpack[Ts]]
 ]
 
 


### PR DESCRIPTION
## Summary
- represent tuple annotations using `TyApp` instead of a dedicated `TyTuple` node
- validate tuple ellipsis placement and element types in `validate`
- update normalization, emission, resolution, and tests for the new tuple representation

## Testing
- `python -m macrotype macrotype`
- `ruff format`
- `ruff check --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c1faaedd08329a606873fb523ec26