### PR TITLE
refactor: replace TyName with direct type

### DIFF
--- a/macrotype/types/ir.py
+++ b/macrotype/types/ir.py
@@ -51,18 +51,12 @@ class TyNever(Ty):
 
 
 @dataclass(frozen=True, kw_only=True)
-class TyName(Ty):
+class TyType(Ty):
     """
-    A named (possibly-qualified) type without applied parameters.
-
-    Examples:
-      - `int` → TyName("builtins", "int")
-      - `typing.Sequence` → TyName("typing", "Sequence")
-      - `MyClass` → TyName("mymod", "MyClass")
+    A (possibly annotated) regular python type, like int, MyClass, or Sequence.
     """
 
-    module: Optional[str]
-    name: str
+    type_: type
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -71,7 +65,7 @@ class TyApp(Ty):
     Generic application (type constructor applied to type arguments).
 
     Examples:
-      - `list[int]` → TyApp(base=TyName("builtins","list"), args=(TyName("builtins","int"),))
+      - `list[int]` → TyApp(base=TyType(type_=list), args=(TyType(type_=int),))
       - `dict[str, bool]`
       - `Box[T]` where `Box` is user generic
       - `type[Foo]` / `typing.Type[Foo]`

--- a/macrotype/types/normalize.py
+++ b/macrotype/types/normalize.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import typing as t
 from dataclasses import dataclass, replace
 
 from .ir import (
@@ -10,9 +11,9 @@ from .ir import (
     TyApp,
     TyCallable,
     TyLiteral,
-    TyName,
     TyNever,
     TyRoot,
+    TyType,
     TyUnion,
     TyUnpack,
 )
@@ -35,12 +36,12 @@ class NormOpts:
 _DEFAULT = NormOpts()
 
 _TYPING_TO_BUILTINS = {
-    ("typing", "List"): ("builtins", "list"),
-    ("typing", "Dict"): ("builtins", "dict"),
-    ("typing", "Tuple"): ("builtins", "tuple"),
-    ("typing", "Set"): ("builtins", "set"),
-    ("typing", "FrozenSet"): ("builtins", "frozenset"),
-    ("typing", "Type"): ("builtins", "type"),
+    t.List: list,
+    t.Dict: dict,
+    t.Tuple: tuple,
+    t.Set: set,
+    t.FrozenSet: frozenset,
+    t.Type: type,
 }
 
 
@@ -67,12 +68,9 @@ def _norm(n: Ty, o: NormOpts) -> Ty:
         case TyAny() | TyNever():
             res = n
 
-        case TyName(module=mod, name=name):
-            if o.typing_to_builtins:
-                key = (mod, name)
-                if key in _TYPING_TO_BUILTINS:
-                    m, k = _TYPING_TO_BUILTINS[key]
-                    return TyName(module=m, name=k)
+        case TyType(type_=tp):
+            if o.typing_to_builtins and tp in _TYPING_TO_BUILTINS:
+                return TyType(type_=_TYPING_TO_BUILTINS[tp])
             res = n
 
         case TyApp(base=base, args=args):

--- a/tests/test_emit_module.py
+++ b/tests/test_emit_module.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
+import builtins
 from types import ModuleType
 
 from macrotype.emit_module import emit_module
 from macrotype.scanner import ModuleInfo
-from macrotype.types.ir import TyAny, TyApp, TyName, TyRoot
+from macrotype.types.ir import TyAny, TyApp, TyRoot, TyType
 from macrotype.types.symbols import AliasSymbol, ClassSymbol, FuncSymbol, Site, VarSymbol
 
 
-def b(name: str) -> TyName:  # builtins helper
-    return TyName(module="builtins", name=name)
+def b(name: str) -> TyType:  # builtins helper
+    return TyType(type_=getattr(builtins, name))
 
 
 # ---- table: ModuleInfo -> emitted lines ----

--- a/tests/types/test_validate.py
+++ b/tests/types/test_validate.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import builtins
+import typing as t
+from types import EllipsisType
+
 import pytest
 
 from macrotype.types.ir import (
     TyApp,
     TyCallable,
     TyLiteral,
-    TyName,
     TyParamSpec,
     TyRoot,
+    TyType,
     TyTypeVarTuple,
     TyUnion,
     TyUnpack,
@@ -16,12 +20,16 @@ from macrotype.types.ir import (
 from macrotype.types.validate import TypeValidationError, validate
 
 
-def b(name: str) -> TyName:
-    return TyName(module="builtins", name=name)
+def b(name: str) -> TyType:
+    if name == "Ellipsis":
+        return TyType(type_=EllipsisType)
+    if name == "None":
+        return TyType(type_=type(None))
+    return TyType(type_=getattr(builtins, name))
 
 
-def typ(name: str) -> TyName:
-    return TyName(module="typing", name=name)
+def typ(name: str) -> TyType:
+    return TyType(type_=getattr(t, name))
 
 
 # -------- GOOD CASES (should pass) --------


### PR DESCRIPTION
## Summary
- refactor IR to store concrete `type` objects via new `TyType`
- update parsing, normalization, resolution, and validation for `TyType`
- simplify tests to use direct types

## Testing
- `python -m macrotype tests/annotations.py -o tests/annotations.pyi`
- `ruff format`
- `ruff check --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c25000c748329888869b3c286ca2c