### PR TITLE
Consolidate CLI commands into single module

### DIFF
--- a/__macrotype__/macrotype/cli.pyi
+++ b/__macrotype__/macrotype/cli.pyi
@@ -1,9 +1,0 @@
-# Generated via: macrotype macrotype
-# Do not edit by hand
-from pathlib import Path
-
-def _default_output_path(path: Path, cwd: Path, *, is_file: bool) -> Path: ...
-
-def _stdout_write(lines: list[str], command: None | str) -> None: ...
-
-def main(argv: None | list[str]) -> int: ...

--- a/__macrotype__/macrotype/cli/__init__/__init__.pyi
+++ b/__macrotype__/macrotype/cli/__init__/__init__.pyi
@@ -1,0 +1,1 @@
+__macrotype__/macrotype/__init__.pyi

--- a/__macrotype__/macrotype/cli/typecheck.pyi
+++ b/__macrotype__/macrotype/cli/typecheck.pyi
@@ -1,0 +1,1 @@
+__macrotype__/macrotype/typecheck.pyi

--- a/__macrotype__/macrotype/cli/watch.pyi
+++ b/__macrotype__/macrotype/cli/watch.pyi
@@ -1,0 +1,1 @@
+__macrotype__/macrotype/watch.pyi

--- a/macrotype/cli/__init__.py
+++ b/macrotype/cli/__init__.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+DEFAULT_OUT_DIR = Path("__macrotype__")
+
+
+def _default_output_path(path: Path, cwd: Path, *, is_file: bool) -> Path:
+    """Return the default output location for ``path`` relative to ``cwd``."""
+
+    abs_path = path if path.is_absolute() else cwd / path
+    if not abs_path.is_relative_to(cwd):
+        raise ValueError(f"{path} is not under {cwd}; specify -o")
+    rel = abs_path.relative_to(cwd)
+    base = DEFAULT_OUT_DIR / rel
+    return base.with_suffix(".pyi") if is_file else base
+
+
+def main(argv: list[str] | None = None) -> int:
+    from .__main__ import main as _main
+
+    return _main(argv)
+
+
+def check_main(argv: list[str] | None = None) -> int:
+    from .typecheck import main as _main
+
+    return _main(argv)
+
+
+__all__ = ["main", "check_main", "DEFAULT_OUT_DIR", "_default_output_path"]

--- a/macrotype/cli/__main__.py
+++ b/macrotype/cli/__main__.py
@@ -4,29 +4,16 @@ import argparse
 import sys
 from pathlib import Path
 
-from . import stubgen
+from .. import stubgen
+from . import DEFAULT_OUT_DIR, _default_output_path
 from .watch import watch_and_run
-
-DEFAULT_OUT_DIR = Path("__macrotype__")
-
-
-def _default_output_path(path: Path, cwd: Path, *, is_file: bool) -> Path:
-    """Return the default output location for ``path`` relative to ``cwd``."""
-
-    abs_path = path if path.is_absolute() else cwd / path
-    if not abs_path.is_relative_to(cwd):
-        raise ValueError(f"{path} is not under {cwd}; specify -o")
-    rel = abs_path.relative_to(cwd)
-    base = DEFAULT_OUT_DIR / rel
-    return base.with_suffix(".pyi") if is_file else base
 
 
 def _stdout_write(lines: list[str], command: str | None = None) -> None:
     sys.stdout.write("\n".join(stubgen._header_lines(command) + lines) + "\n")
 
 
-def main(argv: list[str] | None = None) -> int:
-    argv = list(argv or sys.argv[1:])
+def _stub_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser(prog="macrotype")
     parser.add_argument(
         "paths",
@@ -121,6 +108,11 @@ def main(argv: list[str] | None = None) -> int:
                 stub_overlay_dir=overlay,
             )
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(argv or sys.argv[1:])
+    return _stub_main(argv)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/macrotype/cli/typecheck.py
+++ b/macrotype/cli/typecheck.py
@@ -6,8 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
-from . import stubgen
-from .cli import DEFAULT_OUT_DIR, _default_output_path
+from .. import stubgen
+from . import DEFAULT_OUT_DIR, _default_output_path
 from .watch import watch_and_run
 
 
@@ -54,7 +54,7 @@ def main(argv: list[str] | None = None) -> int:
         cmd = [
             sys.executable,
             "-m",
-            "macrotype.typecheck",
+            "macrotype.cli.typecheck",
             *[a for a in cli_argv if a not in {"-w", "--watch"}],
         ]
         if tool_args:

--- a/macrotype/cli/watch.py
+++ b/macrotype/cli/watch.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from threading import Event
 from typing import Iterable
 
-from . import stubgen
+from .. import stubgen
 
 
 def _snapshot(paths: Iterable[Path]) -> dict[Path, float]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ where = ["."]
 
 [project.scripts]
 macrotype = "macrotype.cli:main"
-macrotype-check = "macrotype.typecheck:main"
+macrotype-check = "macrotype.cli:check_main"
 
 [project.optional-dependencies]
 test = ["mypy", "pyright", "ruff", "pytest"]

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -41,6 +41,7 @@ def test_cli_stdout(tmp_path, src: str, expected: str) -> None:
 @pytest.mark.parametrize("src, expected", CASES)
 def test_stub_generation_matches_expected(src: str, expected: str) -> None:
     src_path = Path(__file__).with_name(src)
+    sys.modules.pop(f"tests.{src_path.stem}", None)
     loaded = load_module_from_path(src_path)
     module = PyiModule.from_module(loaded)
     generated = module.render()
@@ -54,6 +55,7 @@ def test_stub_generation_matches_expected(src: str, expected: str) -> None:
 @pytest.mark.parametrize("src, expected", CASES)
 def test_process_file(tmp_path, src: str, expected: str) -> None:
     src_path = Path(__file__).with_name(src)
+    sys.modules.pop(f"tests.{src_path.stem}", None)
     dest = tmp_path / f"out_{src_path.stem}.pyi"
     process_file(src_path, dest)
     expected_lines = Path(__file__).with_name(expected).read_text().splitlines()[2:]

--- a/tests/test_typechecker_integration.py
+++ b/tests/test_typechecker_integration.py
@@ -13,7 +13,7 @@ def test_macrotype_check(tmp_path: Path, tool: str) -> None:
     cmd = [
         sys.executable,
         "-m",
-        "macrotype.typecheck",
+        "macrotype.cli.typecheck",
         tool,
         "tests/annotations.py",
         "-o",

--- a/tests/test_watch_mode.py
+++ b/tests/test_watch_mode.py
@@ -4,7 +4,7 @@ import threading
 import time
 from pathlib import Path
 
-from macrotype.watch import watch_and_run
+from macrotype.cli.watch import watch_and_run
 
 
 def test_watch_and_run_regenerates(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- move CLI code into `macrotype.cli` package with `__main__` entry point
- nest `typecheck` and `watch` modules under `macrotype.cli`
- update README and tests for the new package layout

## Testing
- `ruff format macrotype/cli/__main__.py macrotype/cli/typecheck.py macrotype/cli/__init__.py macrotype/cli/watch.py macrotype/stubgen.py tests/test_watch_mode.py tests/test_typechecker_integration.py`
- `ruff check --fix macrotype/cli/__main__.py macrotype/cli/typecheck.py macrotype/cli/__init__.py macrotype/cli/watch.py macrotype/stubgen.py tests/test_watch_mode.py tests/test_typechecker_integration.py`
- `ruff format tests/test_all.py`
- `ruff check --fix tests/test_all.py`
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_689c2f2de9c88329a7f64b957ad14927