### PR TITLE
Handle Annotated metadata strings

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import types
-from typing import Any, ForwardRef, Literal, Union, get_args, get_origin
+from typing import Annotated, Any, ForwardRef, Literal, Union, get_args, get_origin
 
 INDENT = "    "
 
@@ -140,6 +140,16 @@ def stringify_annotation(ann: Any, name_map: dict[Any, str]) -> str:
             else:
                 inner_parts.append(stringify_annotation(arg, name_map))
         return f"Literal[{', '.join(inner_parts)}]"
+
+    if origin is Annotated:
+        first, *metas = args
+        parts = [stringify_annotation(first, name_map)]
+        for meta in metas:
+            if isinstance(meta, str):
+                parts.append(repr(meta))
+            else:
+                parts.append(stringify_annotation(meta, name_map))
+        return f"Annotated[{', '.join(parts)}]"
 
     if origin:
         name = name_map.get(origin, getattr(origin, "__name__", repr(origin)))

--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import ModuleType
-from typing import Any, ClassVar, Literal
+from typing import Annotated, Any, ClassVar, Literal
 
 from macrotype.modules.emit import emit_module
 from macrotype.modules.scanner import ModuleInfo
@@ -70,7 +70,42 @@ case3 = (
     ),
     ["from typing import Literal", "", "lit: Literal['hi']"],
 )
-CASES = [case1, case2, case3]
+mod4 = ModuleType("m4")
+case4 = (
+    ModuleInfo(
+        mod=mod4,
+        symbols=[
+            VarSymbol(
+                name="ann",
+                site=Site(role="var", annotation=Annotated[int, "meta"]),
+            ),
+        ],
+    ),
+    ["from typing import Annotated", "", "ann: Annotated[int, 'meta']"],
+)
+
+mod5 = ModuleType("m5")
+case5 = (
+    ModuleInfo(
+        mod=mod5,
+        symbols=[
+            VarSymbol(
+                name="nested",
+                site=Site(
+                    role="var",
+                    annotation=Annotated[Annotated[int, "inner"], "outer"],
+                ),
+            ),
+        ],
+    ),
+    [
+        "from typing import Annotated",
+        "",
+        "nested: Annotated[int, 'inner', 'outer']",
+    ],
+)
+
+CASES = [case1, case2, case3, case4, case5]
 
 
 def test_emit_module_table() -> None:


### PR DESCRIPTION
## Summary
- ensure stringify_annotation emits Annotated metadata strings with quotes
- test Annotated metadata emission for simple and nested cases

## Testing
- `ruff format macrotype/modules/emit.py tests/modules/test_emit.py`
- `ruff check --fix tests/modules/test_emit.py macrotype/modules/emit.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cacc154608329b7dbe36685fbc040