### PR TITLE
Preserve typing.Union and string literals in emitter

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import types
 from collections.abc import Callable
-from typing import Annotated, Any, ForwardRef, Iterable, Literal, Union, get_args, get_origin
+from typing import Annotated, Any, ForwardRef, Iterable, get_args, get_origin
 
 INDENT = "    "
 
@@ -135,23 +135,13 @@ def stringify_annotation(ann: Any, name_map: dict[int, str]) -> str:
         return ann.__forward_arg__
 
     if isinstance(ann, str):
-        return ann  # literal forward ref
+        return repr(ann)
 
     origin = get_origin(ann)
     args = get_args(ann)
 
-    if origin in (types.UnionType, Union):
+    if origin is types.UnionType:
         return " | ".join(stringify_annotation(arg, name_map) for arg in args)
-
-    if origin is Literal:
-        inner_parts: list[str] = []
-        for arg in args:
-            if isinstance(arg, str):
-                inner_parts.append(repr(arg))
-            else:
-                inner_parts.append(stringify_annotation(arg, name_map))
-        return f"Literal[{', '.join(inner_parts)}]"
-
 
     if origin is Callable:
         if not args:

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -179,7 +179,7 @@ class Basic:
     simple: list[str]
     mapping: dict[str, int]
     optional: Optional[int]
-    union: Union[int, str]
+    union: Union[int, str]  # typing.Union should remain unaltered
     pipe_union: int | str
     func: Callable[[int, str], bool]
     annotated: Annotated[int, "meta"]

--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import ModuleType
-from typing import Annotated, Any, Callable, ClassVar, Literal
+from typing import Annotated, Any, Callable, ClassVar, Literal, Union
 
 from macrotype.modules.emit import emit_module
 from macrotype.modules.scanner import ModuleInfo
@@ -106,7 +106,7 @@ case4 = (
         "",
         "nested: list[Callable[[int], str]]",
         "",
-        "combo: Callable[[int], str] | Callable[..., bool]",
+        "combo: Union[Callable[[int], str], Callable[..., bool]]",
     ],
 )
 
@@ -145,7 +145,24 @@ case6 = (
     ],
 )
 
-CASES = [case1, case2, case3, case4, case5, case6]
+mod7 = ModuleType("m7")
+case7 = (
+    ModuleInfo(
+        mod=mod7,
+        symbols=[
+            VarSymbol(name="u", site=Site(role="var", annotation=Union[int, str])),
+            VarSymbol(name="s", site=Site(role="var", annotation="A")),
+        ],
+    ),
+    [
+        "from typing import Union",
+        "",
+        "u: Union[int, str]",
+        "",
+        "s: 'A'",
+    ],
+)
+CASES = [case1, case2, case3, case4, case5, case6, case7]
 
 
 def test_emit_module_table() -> None:


### PR DESCRIPTION
## Summary
- avoid rewriting `typing.Union` annotations into PEP 604 pipe unions
- keep raw string annotations quoted when emitting stubs
- cover union and string pass-through in module emitter tests
- drop special-case handling for `Literal` now that strings are quoted generically

## Testing
- `python -m macrotype tests/annotations.py -o tests/annotations.pyi`
- `ruff format macrotype/modules/emit.py tests/annotations.py tests/modules/test_emit.py`
- `ruff check --fix macrotype/modules/emit.py tests/annotations.py tests/modules/test_emit.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689cc202f7d883299488da850c4f9b53