### PR TITLE
feat: carry through source comments

### DIFF
--- a/macrotype/modules/__init__.py
+++ b/macrotype/modules/__init__.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 import typing as t
 from types import ModuleType
 
+from .add_comment_transform import add_comments
 from .emit import emit_module
 from .scanner import ModuleInfo, scan_module
 
 
 def from_module(glb_or_mod: ModuleType | t.Mapping[str, t.Any]) -> ModuleInfo:
-    """Scan *glb_or_mod* into a ModuleInfo."""
+    """Scan *glb_or_mod* into a ModuleInfo and attach comments."""
 
-    return scan_module(glb_or_mod)
+    mi = scan_module(glb_or_mod)
+    add_comments(mi)
+    return mi
 
 
-__all__ = ["ModuleInfo", "from_module", "emit_module", "scan_module"]
+__all__ = ["ModuleInfo", "add_comments", "from_module", "emit_module", "scan_module"]

--- a/macrotype/modules/add_comment_transform.py
+++ b/macrotype/modules/add_comment_transform.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import inspect
+import io
+import re
+import tokenize
+from types import ModuleType
+
+from .scanner import ModuleInfo
+from .symbols import AliasSymbol, ClassSymbol, FuncSymbol, Symbol, VarSymbol
+
+
+def _line_comment(line: str) -> str | None:
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(line).readline):
+            if tok.type == tokenize.COMMENT:
+                return tok.string[1:].strip()
+    except tokenize.TokenError:
+        return None
+    return None
+
+
+def _extract_name(line: str) -> str | None:
+    stripped = line.lstrip()
+    if stripped.startswith("def "):
+        return stripped[4:].split("(", 1)[0].strip()
+    if stripped.startswith("class "):
+        return stripped[6:].split("(", 1)[0].split(":", 1)[0].strip()
+    if stripped.startswith("type "):
+        tail = stripped[5:]
+        return re.split(r"[\s\[=]", tail, 1)[0]
+    m = re.match(r"([A-Za-z_][A-Za-z0-9_]*)\s*[:=]", stripped)
+    if m:
+        return m.group(1)
+    return None
+
+
+def _build_comment_map_from_lines(lines: list[str]) -> dict[str, str]:
+    cmap: dict[str, str] = {}
+    for line in lines:
+        comment = _line_comment(line)
+        if not comment:
+            continue
+        name = _extract_name(line)
+        if name:
+            cmap[name] = comment
+    return cmap
+
+
+def _build_comment_map(obj: ModuleType | type) -> dict[str, str]:
+    try:
+        lines, _ = inspect.getsourcelines(obj)
+    except OSError:
+        return {}
+    return _build_comment_map_from_lines(lines)
+
+
+def _attach(sym: Symbol, obj: object | None, cmap: dict[str, str]) -> None:
+    comment = cmap.get(sym.name)
+    sym.comment = comment
+
+    match sym:
+        case VarSymbol(site=site):
+            site.comment = comment
+        case AliasSymbol(value=site):
+            if site:
+                site.comment = comment
+        case FuncSymbol():
+            pass
+        case ClassSymbol(td_fields=fields, members=members):
+            if inspect.isclass(obj):
+                inner_map = _build_comment_map(obj)
+                for f in fields:
+                    f.comment = inner_map.get(f.name)
+                for m in members:
+                    m_obj = getattr(obj, m.name, None)
+                    _attach(m, m_obj, inner_map)
+
+
+def add_comments(mi: ModuleInfo) -> None:
+    """Attach same-line source comments to symbols within ``mi``."""
+    cmap = _build_comment_map(mi.mod)
+    for sym in mi.symbols:
+        obj = getattr(mi.mod, sym.name, None)
+        _attach(sym, obj, cmap)

--- a/macrotype/modules/scanner.py
+++ b/macrotype/modules/scanner.py
@@ -5,14 +5,7 @@ import typing as t
 from dataclasses import dataclass, replace
 from types import ModuleType
 
-from .symbols import (
-    AliasSymbol,
-    ClassSymbol,
-    FuncSymbol,
-    Site,
-    Symbol,
-    VarSymbol,
-)
+from .symbols import AliasSymbol, ClassSymbol, FuncSymbol, Site, Symbol, VarSymbol
 
 
 @dataclass
@@ -170,4 +163,5 @@ def _scan_class(cls: type) -> ClassSymbol:
         is_typeddict=is_td,
         td_total=td_total,
         members=tuple(members),
+        comment=None,
     )

--- a/macrotype/modules/symbols.py
+++ b/macrotype/modules/symbols.py
@@ -5,29 +5,31 @@ from types import EllipsisType
 from typing import Literal, Optional
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class Symbol:
     """Base class for all top-level or nested declarations."""
 
     name: str
+    comment: str | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class Site:
     role: Literal["var", "return", "param", "base", "alias_value", "td_field"]
     name: Optional[str] = None
     index: Optional[int] = None
     annotation: object
+    comment: str | None = None
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class VarSymbol(Symbol):
     site: Site
     initializer: object | EllipsisType = Ellipsis
     flags: dict[str, bool] = field(default_factory=dict)  # final, classvar
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class FuncSymbol(Symbol):
     params: tuple[Site, ...]
     ret: Optional[Site]
@@ -35,7 +37,7 @@ class FuncSymbol(Symbol):
     flags: dict[str, bool] = field(default_factory=dict)  # e.g., staticmethod, classmethod
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class ClassSymbol(Symbol):
     bases: tuple[Site, ...]
     td_fields: tuple[Site, ...] = ()
@@ -45,6 +47,6 @@ class ClassSymbol(Symbol):
     flags: dict[str, bool] = field(default_factory=dict)  # e.g., protocol, abstract
 
 
-@dataclass(frozen=True, kw_only=True)
+@dataclass(kw_only=True)
 class AliasSymbol(Symbol):
     value: Optional[Site]

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -134,6 +134,9 @@ BOOL_FALSE = False
 SITE_PROV_VAR: int = 1
 
 
+COMMENTED_VAR: int = 1  # pragma: var
+
+
 # Unannotated parameters infer type from default values
 def mult(a, b=1):
     return a * b
@@ -142,6 +145,10 @@ def mult(a, b=1):
 # Defaults of ``None`` do not refine "Any"
 def takes_optional(x=None):
     return x
+
+
+def commented_func(x: int) -> None:  # pragma: func
+    pass
 
 
 # Edge case: lambda expressions should be treated as variables, not functions

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -109,9 +109,13 @@ BOOL_FALSE: bool
 
 SITE_PROV_VAR: int
 
+COMMENTED_VAR: int  # pragma: var
+
 def mult(a, b: int): ...
 
 def takes_optional(x): ...
+
+def commented_func(x: int) -> None: ...  # pragma: func
 
 UNTYPED_LAMBDA: function
 


### PR DESCRIPTION
## Summary
- add mutable comment fields to symbols and sites
- introduce add_comment_transform to attach line-ending comments post-scan
- integrate comment transform into module pipeline while simplifying scanner

## Testing
- `ruff check macrotype/modules/symbols.py macrotype/modules/scanner.py macrotype/modules/add_comment_transform.py macrotype/modules/__init__.py`
- `pytest tests/test_all.py::test_cli_stdout[annotations.py-annotations.pyi] -q`


------
https://chatgpt.com/codex/tasks/task_e_689cf730dbf0832990bdf1eedac06dda