### PR TITLE
feat: normalize method descriptors

### DIFF
--- a/macrotype/modules/__init__.py
+++ b/macrotype/modules/__init__.py
@@ -6,6 +6,7 @@ from types import ModuleType
 
 from .add_comment_transform import add_comments
 from .dataclass_transform import transform_dataclasses
+from .descriptor_transform import normalize_descriptors
 from .emit import emit_module
 from .scanner import ModuleInfo, scan_module
 
@@ -15,6 +16,7 @@ def from_module(mod: ModuleType) -> ModuleInfo:
 
     mi = scan_module(mod)
     transform_dataclasses(mi)
+    normalize_descriptors(mi)
     add_comments(mi)
     return mi
 
@@ -23,6 +25,7 @@ __all__ = [
     "ModuleInfo",
     "add_comments",
     "from_module",
+    "normalize_descriptors",
     "emit_module",
     "scan_module",
     "transform_dataclasses",

--- a/macrotype/modules/descriptor_transform.py
+++ b/macrotype/modules/descriptor_transform.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+"""Normalize method descriptors into function symbols."""
+
+import functools
+from dataclasses import replace
+from typing import Any
+
+from .scanner import ModuleInfo, _scan_function
+from .symbols import ClassSymbol, FuncSymbol
+
+# Mapping of descriptor types to the attribute holding the underlying
+# function and the decorator string to attach.
+_ATTR_DECORATORS: dict[type, tuple[str, str]] = {
+    classmethod: ("__func__", "classmethod"),
+    staticmethod: ("__func__", "staticmethod"),
+    property: ("fget", "property"),
+    functools.cached_property: ("func", "cached_property"),
+}
+
+
+def _unwrap_descriptor(obj: Any) -> Any | None:
+    """Return the underlying descriptor for *obj* if wrapped."""
+
+    while True:
+        for typ in _ATTR_DECORATORS:
+            if isinstance(obj, typ):
+                return obj
+        if hasattr(obj, "__wrapped__"):
+            obj = obj.__wrapped__
+            continue
+        return None
+
+
+def _descriptor_members(attr_name: str, attr: Any) -> list[FuncSymbol]:
+    """Return function symbols generated from descriptor *attr*."""
+
+    unwrapped = _unwrap_descriptor(attr) or attr
+
+    for attr_type, (func_attr, deco) in _ATTR_DECORATORS.items():
+        if isinstance(unwrapped, attr_type):
+            fn_obj = getattr(unwrapped, func_attr)
+            for flag in ("__final__", "__override__", "__isabstractmethod__"):
+                if getattr(attr, flag, False) and not getattr(fn_obj, flag, False):
+                    setattr(fn_obj, flag, True)
+
+            fn_sym = _scan_function(fn_obj)
+            fn_sym = replace(fn_sym, name=attr_name, decorators=fn_sym.decorators + (deco,))
+            members = [fn_sym]
+
+            if attr_type is property:
+                if unwrapped.fset is not None:
+                    setter = _scan_function(unwrapped.fset)
+                    setter = replace(
+                        setter,
+                        name=attr_name,
+                        decorators=setter.decorators + (f"{attr_name}.setter",),
+                    )
+                    members.append(setter)
+                if unwrapped.fdel is not None:
+                    deleter = _scan_function(unwrapped.fdel)
+                    deleter = replace(
+                        deleter,
+                        name=attr_name,
+                        decorators=deleter.decorators + (f"{attr_name}.deleter",),
+                    )
+                    members.append(deleter)
+
+            return members
+
+    return []
+
+
+def _transform_class(sym: ClassSymbol, cls: type) -> None:
+    members = list(sym.members)
+
+    for attr_name, attr in cls.__dict__.items():
+        desc_members = _descriptor_members(attr_name, attr)
+        if desc_members:
+            for i, m in enumerate(members):
+                if m.name == attr_name:
+                    members[i : i + 1] = desc_members
+                    break
+            else:
+                members.extend(desc_members)
+
+    sym.members = tuple(members)
+
+    for m in sym.members:
+        if isinstance(m, ClassSymbol):
+            inner = getattr(cls, m.name, None)
+            if isinstance(inner, type):
+                _transform_class(m, inner)
+
+
+def normalize_descriptors(mi: ModuleInfo) -> None:
+    """Normalize descriptors within ``mi`` into function symbols."""
+
+    for sym in mi.symbols:
+        if isinstance(sym, ClassSymbol):
+            cls = getattr(mi.mod, sym.name, None)
+            if isinstance(cls, type):
+                _transform_class(sym, cls)

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -258,6 +258,18 @@ class OverrideLate(Basic):
         return 2
 
 
+# Property with both setter and deleter
+class ManualProperty:
+    @property
+    def both(self) -> int: ...
+
+    @both.setter
+    def both(self, value: int) -> None: ...
+
+    @both.deleter
+    def both(self) -> None: ...
+
+
 class SampleDict(TypedDict):
     name: str
     age: int

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -28,10 +28,10 @@ from typing import (
     Protocol,
     Required,
     Self,
+    TypedDict,
     TypeGuard,
     TypeVar,
     TypeVarTuple,
-    TypedDict,
     Unpack,
     final,
     overload,
@@ -112,26 +112,24 @@ SITE_PROV_VAR: int
 COMMENTED_VAR: int  # pragma: var
 
 def mult(a, b: int): ...
-
 def takes_optional(x): ...
-
 def commented_func(x: int) -> None: ...  # pragma: func
 
 UNTYPED_LAMBDA: function
 
 TYPED_LAMBDA: Callable[[int, int], int]
 
-ANNOTATED_EXTRA: Annotated[str, 'extra']
+ANNOTATED_EXTRA: Annotated[str, "extra"]
 
-NESTED_ANNOTATED: Annotated[int, 'a', 'b']
+NESTED_ANNOTATED: Annotated[int, "a", "b"]
 
-TRIPLE_ANNOTATED: Annotated[int, 'x', 'y', 'z']
+TRIPLE_ANNOTATED: Annotated[int, "x", "y", "z"]
 
-ANNOTATED_OPTIONAL_META: Annotated[None | int, 'meta']
+ANNOTATED_OPTIONAL_META: Annotated[None | int, "meta"]
 
-ANNOTATED_FINAL_META: Final[Annotated[int, 'meta']]
+ANNOTATED_FINAL_META: Final[Annotated[int, "meta"]]
 
-ANNOTATED_WRAP_GENERIC: Annotated[list[Annotated[int, 'inner']], 'outer']
+ANNOTATED_WRAP_GENERIC: Annotated[list[Annotated[int, "inner"]], "outer"]
 
 class UserBox[T]: ...
 
@@ -142,13 +140,13 @@ class Basic:
     union: int | str
     pipe_union: int | str
     func: Callable[[int, str], bool]
-    annotated: Annotated[int, 'meta']
+    annotated: Annotated[int, "meta"]
     pattern: Pattern[str]
     uid: UserId
-    lit_attr: Literal['a', 'b']
+    lit_attr: Literal["a", "b"]
     def copy[T](self, param: T) -> T: ...
     def curry[**P](self, f: Callable[P, int]) -> Callable[P, int]: ...
-    def literal_method(self, flag: Literal['on', 'off']) -> Literal[1, 0]: ...
+    def literal_method(self, flag: Literal["on", "off"]) -> Literal[1, 0]: ...
     @classmethod
     def cls_method(cls, value: int) -> Basic: ...
     @classmethod
@@ -187,6 +185,14 @@ class OverrideLate(Basic):
     @override
     def static_override() -> int: ...
 
+class ManualProperty:
+    @property
+    def both(self) -> int: ...
+    @both.setter
+    def both(self, value: int) -> None: ...
+    @both.deleter
+    def both(self) -> None: ...
+
 class SampleDict(TypedDict):
     name: str
     age: int
@@ -224,10 +230,8 @@ class GeneratedInt:
 
 @overload
 def over(x: int) -> int: ...
-
 @overload
 def over(x: str) -> str: ...
-
 @dataclass
 class Point:
     x: int
@@ -303,8 +307,8 @@ class Permission(IntFlag):
     EXECUTE = 4
 
 class StrEnum(str, Enum):
-    A = 'a'
-    B = 'b'
+    A = "a"
+    B = "b"
 
 class NamedPoint(NamedTuple):
     x: int
@@ -332,21 +336,13 @@ class Info(TypedDict):
     age: int
 
 def with_kwargs(**kwargs: Unpack[Info]) -> Info: ...
-
 def sum_of(*args: tuple[int, ...]) -> int: ...
-
 def dict_echo(**kwargs: dict[str, Any]) -> dict[str, Any]: ...
-
 def use_params[**P](func: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
-
 def do_nothing() -> None: ...
-
 def always_raises() -> NoReturn: ...
-
 def never_returns() -> Never: ...
-
 def is_str_list(val: list[object]) -> TypeGuard[list[str]]: ...
-
 def is_int(val: object) -> TypeGuard[int]: ...
 
 PLAIN_FINAL_VAR: Final[int]
@@ -366,9 +362,7 @@ def echo_literal(value: LiteralString) -> LiteralString: ...
 NONE_VAR: None
 
 async def async_add_one(x: int) -> int: ...
-
 async def gen_range(n: int) -> AsyncIterator[int]: ...
-
 @final
 class FinalClass: ...
 
@@ -377,24 +371,15 @@ class HasFinalMethod:
     def do_final(self) -> None: ...
 
 def final_func(x: int) -> int: ...
-
 def pragma_func(x: int) -> int: ...  # pyright: ignore
-
 def pos_only_func(a: int, b: str, /) -> None: ...
-
 def kw_only_func(*, x: int, y: str) -> None: ...
-
 def pos_and_kw(a: int, /, b: int, *, c: int) -> None: ...
-
 def iter_sequence(seq: Sequence[int]) -> Iterator[int]: ...
-
 def simple_wrap(fn: Callable[[int], int]) -> Callable[[int], int]: ...
-
 def double_wrapped(x: int) -> int: ...
-
 def cached_add(a: int, b: int) -> int: ...
-
-def annotated_fn(x: Annotated[int, 'inp']) -> Annotated[str, 'out']: ...
+def annotated_fn(x: Annotated[int, "inp"]) -> Annotated[str, "out"]: ...
 
 class FutureClass: ...
 
@@ -411,9 +396,7 @@ class WrappedDescriptors:
     def wrapped_cached(self) -> int: ...
 
 def make_emitter(name: str): ...
-
 def emitted_a(x: int) -> int: ...
-
 def make_emitter_cls(name: str): ...
 
 class EmittedCls:
@@ -425,18 +408,15 @@ class FixedModuleCls: ...
 
 class EmittedMap:
     @overload
-    def __getitem__(self, key: Literal['a']) -> Literal[1]: ...
+    def __getitem__(self, key: Literal["a"]) -> Literal[1]: ...
     @overload
-    def __getitem__(self, key: Literal['b']) -> Literal[2]: ...
+    def __getitem__(self, key: Literal["b"]) -> Literal[2]: ...
 
 def path_passthrough(p: Path) -> Path: ...
-
 @overload
 def loop_over(x: bytearray) -> str: ...
-
 @overload
 def loop_over(x: bytes) -> str: ...
-
 def as_tuple[*Ts](*args: Unpack[Ts]) -> tuple[Unpack[Ts]]: ...
 
 class Variadic[*Ts]:
@@ -444,34 +424,24 @@ class Variadic[*Ts]:
     def to_tuple(self) -> tuple[Unpack[Ts]]: ...
 
 def prepend_one[**P](fn: Callable[Concatenate[int, P], int]) -> Callable[P, int]: ...
-
 @overload
 def special_neg(val: Literal[0]) -> Literal[0]: ...
-
 @overload
 def special_neg(val: Literal[1]) -> Literal[-1]: ...
-
 @overload
 def special_neg(val: int) -> int: ...
-
 @overload
 def parse_int_or_none(val: None) -> None: ...
-
 @overload
 def parse_int_or_none(val: None | str) -> None | int: ...
-
 @overload
 def times_two(val: Literal[3], factor: Literal[2]) -> Literal[6]: ...
-
 @overload
 def times_two(val: int, factor: int) -> int: ...
-
 @overload
 def bool_gate(flag: Literal[True]) -> Literal[1]: ...
-
 @overload
 def bool_gate(flag: Literal[False]) -> Literal[0]: ...
-
 @overload
 def bool_gate(flag: bool) -> int: ...
 


### PR DESCRIPTION
## Summary
- add transformer to flatten descriptor attributes into functions with explicit decorators
- handle properties, staticmethods, classmethods, and cached properties
- test property with both setter and deleter

## Testing
- `ruff format`
- `ruff check --fix`
- `python -m macrotype tests/annotations.py -o tests/annotations.pyi`
- `pytest tests/test_all.py::test_stub_generation_matches_expected tests/modules/test_emit.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d01cbc40083298b6be143820f137b