### PR TITLE
Add final/override/abstract flag normalization

### DIFF
--- a/macrotype/modules/__init__.py
+++ b/macrotype/modules/__init__.py
@@ -9,6 +9,7 @@ from .alias_transform import synthesize_aliases
 from .dataclass_transform import transform_dataclasses
 from .descriptor_transform import normalize_descriptors
 from .emit import emit_module
+from .flag_transform import normalize_flags
 from .overload_transform import expand_overloads
 from .scanner import ModuleInfo, scan_module
 
@@ -20,6 +21,7 @@ def from_module(mod: ModuleType) -> ModuleInfo:
     synthesize_aliases(mi)
     transform_dataclasses(mi)
     normalize_descriptors(mi)
+    normalize_flags(mi)
     expand_overloads(mi)
     add_comments(mi)
     return mi
@@ -30,6 +32,7 @@ __all__ = [
     "add_comments",
     "from_module",
     "expand_overloads",
+    "normalize_flags",
     "normalize_descriptors",
     "synthesize_aliases",
     "emit_module",

--- a/macrotype/modules/flag_transform.py
+++ b/macrotype/modules/flag_transform.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+"""Normalize ``final``/``override``/``abstract`` flags on symbols."""
+
+import inspect
+from typing import Any
+
+from .scanner import ModuleInfo
+from .symbols import ClassSymbol, FuncSymbol
+
+
+def _normalize_function(sym: FuncSymbol, fn: Any, *, is_method: bool) -> None:
+    """Attach flag information for *fn* to ``sym``."""
+
+    flags = sym.flags
+    decos = list(sym.decorators)
+
+    if getattr(fn, "__final__", False):
+        flags["final"] = True
+        if is_method:
+            decos.append("final")
+    if getattr(fn, "__override__", False):
+        flags["override"] = True
+        if is_method:
+            decos.append("override")
+    if getattr(fn, "__isabstractmethod__", False):
+        flags["abstract"] = True
+        if is_method:
+            decos.append("abstractmethod")
+
+    norm: list[str] = []
+    seen: set[str] = set()
+    for deco in decos:
+        base = deco.split(".")[-1]
+        if base == "final":
+            flags["final"] = True
+            if is_method and base not in seen:
+                norm.append("final")
+                seen.add("final")
+        elif base == "override":
+            flags["override"] = True
+            if base not in seen:
+                norm.append("override")
+                seen.add("override")
+        elif base == "abstractmethod":
+            flags["abstract"] = True
+            if is_method and base not in seen:
+                norm.append("abstractmethod")
+                seen.add("abstractmethod")
+        else:
+            if deco not in seen:
+                norm.append(deco)
+                seen.add(deco)
+    sym.decorators = tuple(norm)
+
+
+def _normalize_class(sym: ClassSymbol, cls: type) -> None:
+    flags = sym.flags
+    decos = list(sym.decorators)
+
+    if getattr(cls, "__final__", False):
+        flags["final"] = True
+        decos.append("final")
+    if inspect.isabstract(cls):
+        flags["abstract"] = True
+
+    norm: list[str] = []
+    seen: set[str] = set()
+    for deco in decos:
+        base = deco.split(".")[-1]
+        if base == "final":
+            flags["final"] = True
+            if base not in seen:
+                norm.append("final")
+                seen.add("final")
+        else:
+            if deco not in seen:
+                norm.append(deco)
+                seen.add(deco)
+    sym.decorators = tuple(norm)
+
+    for m in sym.members:
+        if isinstance(m, FuncSymbol):
+            fn = getattr(cls, m.name, None)
+            if callable(fn):
+                _normalize_function(m, fn, is_method=True)
+        elif isinstance(m, ClassSymbol):
+            inner = getattr(cls, m.name, None)
+            if isinstance(inner, type):
+                _normalize_class(m, inner)
+
+
+def normalize_flags(mi: ModuleInfo) -> None:
+    """Attach ``final``/``override``/``abstract`` flags to symbols in ``mi``."""
+
+    for sym in mi.symbols:
+        if isinstance(sym, FuncSymbol):
+            fn = getattr(mi.mod, sym.name, None)
+            if callable(fn):
+                _normalize_function(sym, fn, is_method=False)
+        elif isinstance(sym, ClassSymbol):
+            cls = getattr(mi.mod, sym.name, None)
+            if isinstance(cls, type):
+                _normalize_class(sym, cls)

--- a/tests/modules/test_symbols.py
+++ b/tests/modules/test_symbols.py
@@ -164,3 +164,38 @@ def test_expand_overloads_transform() -> None:
     mixed = [s for s in mi.symbols if s.name == "mixed_overload"]
     assert len(mixed) == 3
     assert mixed[-1].params[0].annotation == (int | str)
+
+
+def test_flag_transform() -> None:
+    ann = importlib.import_module("tests.annotations")
+    mi = from_module(ann)
+
+    fc = next(s for s in mi.symbols if s.name == "FinalClass")
+    assert isinstance(fc, ClassSymbol)
+    assert fc.flags.get("final") is True
+
+    hfm = next(s for s in mi.symbols if s.name == "HasFinalMethod")
+    assert isinstance(hfm, ClassSymbol)
+    fm = next(m for m in hfm.members if isinstance(m, FuncSymbol) and m.name == "do_final")
+    assert fm.flags.get("final") is True
+    assert "final" in fm.decorators
+
+    ff = next(s for s in mi.symbols if s.name == "final_func")
+    assert isinstance(ff, FuncSymbol)
+    assert ff.flags.get("final") is True
+    assert "final" not in ff.decorators
+
+    ol = next(s for s in mi.symbols if s.name == "OverrideLate")
+    assert isinstance(ol, ClassSymbol)
+    cls_override = next(
+        m for m in ol.members if isinstance(m, FuncSymbol) and m.name == "cls_override"
+    )
+    assert cls_override.flags.get("override") is True
+    assert "override" in cls_override.decorators
+
+    ab = next(s for s in mi.symbols if s.name == "AbstractBase")
+    assert isinstance(ab, ClassSymbol)
+    assert ab.flags.get("abstract") is True
+    m = next(m for m in ab.members if isinstance(m, FuncSymbol) and m.name == "do_something")
+    assert m.flags.get("abstract") is True
+    assert "abstractmethod" in m.decorators


### PR DESCRIPTION
## Summary
- normalize final/override/abstract flags on functions and classes
- wire flag normalization into module pipeline
- test flag normalization on annotations fixtures

## Testing
- `ruff check macrotype/modules/flag_transform.py macrotype/modules/__init__.py tests/modules/test_symbols.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d1ba2a6648329965104d5c77de0a3