### PR TITLE
Prune inherited TypedDict fields

### DIFF
--- a/macrotype/modules/__init__.py
+++ b/macrotype/modules/__init__.py
@@ -12,6 +12,7 @@ from .emit import emit_module
 from .flag_transform import normalize_flags
 from .overload_transform import expand_overloads
 from .scanner import ModuleInfo, scan_module
+from .typeddict_transform import prune_inherited_typeddict_fields
 
 
 def from_module(mod: ModuleType) -> ModuleInfo:
@@ -20,6 +21,7 @@ def from_module(mod: ModuleType) -> ModuleInfo:
     mi = scan_module(mod)
     synthesize_aliases(mi)
     transform_dataclasses(mi)
+    prune_inherited_typeddict_fields(mi)
     normalize_descriptors(mi)
     normalize_flags(mi)
     expand_overloads(mi)
@@ -35,6 +37,7 @@ __all__ = [
     "normalize_flags",
     "normalize_descriptors",
     "synthesize_aliases",
+    "prune_inherited_typeddict_fields",
     "emit_module",
     "scan_module",
     "transform_dataclasses",

--- a/macrotype/modules/typeddict_transform.py
+++ b/macrotype/modules/typeddict_transform.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import typing as t
+
+from .scanner import ModuleInfo
+from .symbols import ClassSymbol
+
+
+def _transform_class(sym: ClassSymbol, cls: type, td_meta: type) -> None:
+    if isinstance(cls, td_meta):
+        base_fields: set[str] = set()
+        for base in cls.__mro__[1:]:
+            if isinstance(base, td_meta):
+                base_fields.update(getattr(base, "__annotations__", {}).keys())
+        if base_fields:
+            sym.td_fields = tuple(f for f in sym.td_fields if f.name not in base_fields)
+            sym.td_total = None
+    for m in sym.members:
+        if isinstance(m, ClassSymbol):
+            inner = getattr(cls, m.name, None)
+            if isinstance(inner, type):
+                _transform_class(m, inner, td_meta)
+
+
+def prune_inherited_typeddict_fields(mi: ModuleInfo) -> None:
+    """Remove TypedDict fields shadowed by inherited bases within ``mi``."""
+    td_meta = getattr(t, "_TypedDictMeta", ())
+    for sym in mi.symbols:
+        if isinstance(sym, ClassSymbol):
+            cls = getattr(mi.mod, sym.name, None)
+            if isinstance(cls, type):
+                _transform_class(sym, cls, td_meta)

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -298,6 +298,17 @@ class SubTD(BaseTD):
     sub_field: str
 
 
+# Edge case: TypedDict field shadowing should be pruned
+class TDShadowBase(TypedDict):
+    base_only: int
+    shadow: str
+
+
+class TDShadowChild(TDShadowBase):
+    shadow: str
+    extra: float
+
+
 # Edge case: Generic TypedDict should retain type parameters
 class GenericBox(TypedDict, Generic[TDV]):
     item: TDV

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -216,6 +216,13 @@ class BaseTD(TypedDict):
 class SubTD(BaseTD):
     sub_field: str
 
+class TDShadowBase(TypedDict):
+    base_only: int
+    shadow: str
+
+class TDShadowChild(TDShadowBase):
+    extra: float
+
 class GenericBox[TDV](TypedDict):
     item: TDV
 


### PR DESCRIPTION
## Summary
- add transform to drop TypedDict fields overridden by base classes
- integrate transform into module pipeline
- test TypedDict field shadowing and expected stub output

## Testing
- `ruff format macrotype/modules/typeddict_transform.py macrotype/modules/__init__.py tests/annotations.py`
- `ruff check --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d23bfe3e88329b27a394978895d24