### PR TITLE
Canonicalize foreign variables into aliases

### DIFF
--- a/macrotype/modules/__init__.py
+++ b/macrotype/modules/__init__.py
@@ -10,6 +10,7 @@ from .dataclass_transform import transform_dataclasses
 from .descriptor_transform import normalize_descriptors
 from .emit import emit_module
 from .flag_transform import normalize_flags
+from .foreign_symbol_transform import canonicalize_foreign_symbols
 from .overload_transform import expand_overloads
 from .scanner import ModuleInfo, scan_module
 from .typeddict_transform import prune_inherited_typeddict_fields
@@ -19,6 +20,7 @@ def from_module(mod: ModuleType) -> ModuleInfo:
     """Scan *mod* into a ModuleInfo and attach comments."""
 
     mi = scan_module(mod)
+    canonicalize_foreign_symbols(mi)
     synthesize_aliases(mi)
     transform_dataclasses(mi)
     prune_inherited_typeddict_fields(mi)
@@ -36,6 +38,7 @@ __all__ = [
     "expand_overloads",
     "normalize_flags",
     "normalize_descriptors",
+    "canonicalize_foreign_symbols",
     "synthesize_aliases",
     "prune_inherited_typeddict_fields",
     "emit_module",

--- a/macrotype/modules/foreign_symbol_transform.py
+++ b/macrotype/modules/foreign_symbol_transform.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import typing as t
+
+from .scanner import ModuleInfo
+from .symbols import AliasSymbol, Site, Symbol, VarSymbol
+
+
+def canonicalize_foreign_symbols(mi: ModuleInfo) -> None:
+    """Replace variables referencing foreign objects with aliases."""
+
+    glb = vars(mi.mod)
+    modname = mi.mod.__name__
+    annotations: dict[str, t.Any] = glb.get("__annotations__", {}) or {}
+    new_syms: list[Symbol] = []
+    for sym in mi.symbols:
+        if not isinstance(sym, VarSymbol):
+            new_syms.append(sym)
+            continue
+        obj = glb.get(sym.name, sym.initializer)
+        if obj is Ellipsis:
+            new_syms.append(sym)
+            continue
+        if not hasattr(obj, "__module__"):
+            if sym.name in annotations or isinstance(obj, (int, str, float, bool)):
+                new_syms.append(sym)
+            continue
+        if obj.__module__ != modname:
+            if sym.name in annotations or isinstance(obj, (int, str, float, bool)):
+                new_syms.append(sym)
+                continue
+            alias_name = getattr(obj, "__name__", None)
+            if alias_name and alias_name != sym.name:
+                new_syms.append(
+                    AliasSymbol(
+                        name=sym.name,
+                        value=Site(role="alias_value", annotation=obj),
+                        comment=sym.comment,
+                        emit=sym.emit,
+                    )
+                )
+            continue
+        new_syms.append(sym)
+    mi.symbols = new_syms

--- a/macrotype/modules/scanner.py
+++ b/macrotype/modules/scanner.py
@@ -57,10 +57,8 @@ def scan_module(mod: ModuleType) -> ModuleInfo:
                 syms.append(VarSymbol(name=name, site=site, initializer=obj))
             continue
 
-        if hasattr(obj, "__name__") and getattr(obj, "__module__", None) != modname:
-            site = Site(role="alias_value", annotation=obj)
-            syms.append(AliasSymbol(name=name, value=site))
-            continue
+        site = Site(role="var", name=name, annotation=type(obj))
+        syms.append(VarSymbol(name=name, site=site, initializer=obj))
 
     for name, rann in mod_ann.items():
         if name in seen:

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -559,6 +559,9 @@ PLAIN_FINAL_VAR: Final[int] = 1
 # Edge case: alias to a foreign function should be preserved
 SIN_ALIAS = math.sin
 
+# Foreign function with annotation should stay a variable
+COS_VAR: Callable[[float], float] = math.cos
+
 # Edge case: alias to a foreign constant should retain its type
 PI_ALIAS = math.pi
 

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -370,6 +370,8 @@ PLAIN_FINAL_VAR: Final[int]
 
 SIN_ALIAS = sin
 
+COS_VAR: Callable[[float], float]
+
 PI_ALIAS: float
 
 PRAGMA_VAR: int  # type: ignore


### PR DESCRIPTION
## Summary
- always scan module globals as variables
- convert vars referencing foreign objects into aliases
- add tests for foreign alias handling
- format annotations stub

## Testing
- `python -m macrotype tests/annotations.py -o tests/annotations.pyi`
- `ruff format`
- `ruff check --fix`
- `pytest tests/modules/test_symbols.py::test_aliases tests/modules/test_symbols.py::test_simple_alias_to_foreign -q`


------
https://chatgpt.com/codex/tasks/task_e_689d28431c908329b4b36f4e1e4db324