### PR TITLE
Add NamedTuple transformer

### DIFF
--- a/macrotype/modules/transformers/__init__.py
+++ b/macrotype/modules/transformers/__init__.py
@@ -5,6 +5,7 @@ from .descriptor import normalize_descriptors
 from .enum import transform_enums
 from .flag import normalize_flags
 from .foreign_symbol import canonicalize_foreign_symbols
+from .namedtuple import transform_namedtuples
 from .newtype import transform_newtypes
 from .overload import expand_overloads
 from .protocol import prune_protocol_methods
@@ -22,4 +23,5 @@ __all__ = [
     "transform_newtypes",
     "prune_protocol_methods",
     "prune_inherited_typeddict_fields",
+    "transform_namedtuples",
 ]

--- a/macrotype/modules/transformers/namedtuple.py
+++ b/macrotype/modules/transformers/namedtuple.py
@@ -1,0 +1,38 @@
+"""Normalize NamedTuple classes."""
+
+from __future__ import annotations
+
+import typing as t
+
+from macrotype.modules.scanner import ModuleInfo
+from macrotype.modules.symbols import ClassSymbol, Site, VarSymbol
+
+
+def _transform_class(sym: ClassSymbol, cls: type) -> None:
+    if issubclass(cls, tuple) and hasattr(cls, "_fields"):
+        field_names = set(getattr(cls, "_fields", ()))
+        sym.members = tuple(
+            m for m in sym.members if isinstance(m, VarSymbol) and m.name in field_names
+        )
+        new_bases: list[Site] = [Site(role="base", annotation=t.NamedTuple)]
+        for b in sym.bases:
+            ann = b.annotation
+            if getattr(ann, "__name__", None) == "NamedTuple":
+                continue
+            new_bases.append(b)
+        sym.bases = tuple(new_bases)
+    for m in sym.members:
+        if isinstance(m, ClassSymbol):
+            inner = getattr(cls, m.name, None)
+            if isinstance(inner, type):
+                _transform_class(m, inner)
+
+
+def transform_namedtuples(mi: ModuleInfo) -> None:
+    """Convert NamedTuple classes in ``mi`` to standard form."""
+
+    for sym in mi.symbols:
+        if isinstance(sym, ClassSymbol):
+            cls = getattr(mi.mod, sym.name, None)
+            if isinstance(cls, type):
+                _transform_class(sym, cls)


### PR DESCRIPTION
## Summary
- normalize NamedTuple classes during module transformation
- expose new NamedTuple transformer in package exports
- test NamedTuple handling in transformer suite

## Testing
- `ruff check macrotype/modules/transformers/namedtuple.py macrotype/modules/transformers/__init__.py tests/modules/transformers/test_transformers.py --fix`
- `pytest tests/modules/transformers/test_transformers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d4213e1a8832986bf009382992266