### PR TITLE
Add runtime_checkable support for protocols

### DIFF
--- a/macrotype/modules/__init__.py
+++ b/macrotype/modules/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "canonicalize_foreign_symbols",
     "synthesize_aliases",
     "prune_inherited_typeddict_fields",
+    "prune_protocol_methods",
     "emit_module",
     "scan_module",
     "transform_dataclasses",
@@ -31,6 +32,7 @@ def __getattr__(name: str):
         "normalize_descriptors",
         "normalize_flags",
         "prune_inherited_typeddict_fields",
+        "prune_protocol_methods",
         "synthesize_aliases",
         "transform_dataclasses",
     }:
@@ -52,6 +54,7 @@ def from_module(mod: ModuleType) -> ModuleInfo:
     _t.prune_inherited_typeddict_fields(mi)
     _t.normalize_descriptors(mi)
     _t.normalize_flags(mi)
+    _t.prune_protocol_methods(mi)
     _t.expand_overloads(mi)
     _t.add_comments(mi)
     return mi

--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -53,6 +53,10 @@ def _collect_typing_names(symbols: Iterable[Symbol]) -> set[str]:
     for sym in symbols:
         if not sym.emit:
             continue
+        for deco in getattr(sym, "decorators", ()):  # collect decorator names from typing
+            base = deco.split("(")[0].split(".")[-1]
+            if base in {"final", "override", "overload", "runtime_checkable"}:
+                names.add(base)
         match sym:
             case AliasSymbol(flags=flags):
                 if flags.get("is_typevar"):

--- a/macrotype/modules/transformers/protocol.py
+++ b/macrotype/modules/transformers/protocol.py
@@ -18,6 +18,9 @@ def _transform_class(sym: ClassSymbol, cls: type[Any]) -> None:
             for m in sym.members
             if not (isinstance(m, FuncSymbol) and m.name in _PROTOCOL_METHOD_NAMES)
         )
+        if getattr(cls, "_is_runtime_protocol", False):
+            if "runtime_checkable" not in sym.decorators:
+                sym.decorators = sym.decorators + ("runtime_checkable",)
     for m in sym.members:
         if isinstance(m, ClassSymbol):
             inner = getattr(cls, m.name, None)

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -499,6 +499,14 @@ class Runnable(Protocol):
     def run(self) -> int: ...
 
 
+# runtime_checkable applied after class definition should be preserved
+class LaterRunnable(Protocol):
+    def run(self) -> int: ...
+
+
+LaterRunnable = runtime_checkable(LaterRunnable)
+
+
 # Protocol auto methods should be pruned
 class NoProtoMethods(Protocol):
     pass

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -344,6 +344,10 @@ class SelfFactory:
 class Runnable(Protocol):
     def run(self) -> int: ...
 
+@runtime_checkable
+class LaterRunnable(Protocol):
+    def run(self) -> int: ...
+
 class NoProtoMethods(Protocol): ...
 
 class Info(TypedDict):

--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -176,7 +176,24 @@ case8 = (
     ),
     ["from typing import NewType", "", 'UserId = NewType("UserId", int)'],
 )
-CASES = [case1, case2, case3, case4, case5, case6, case7, case8]
+
+mod9 = ModuleType("m9")
+case9 = (
+    ModuleInfo(
+        mod=mod9,
+        symbols=[
+            ClassSymbol(name="P", bases=(), members=(), decorators=("runtime_checkable",)),
+        ],
+    ),
+    [
+        "from typing import runtime_checkable",
+        "",
+        "@runtime_checkable",
+        "class P:",
+        "    ...",
+    ],
+)
+CASES = [case1, case2, case3, case4, case5, case6, case7, case8, case9]
 
 
 def test_emit_module_table() -> None:

--- a/tests/modules/transformers/test_transformers.py
+++ b/tests/modules/transformers/test_transformers.py
@@ -216,6 +216,22 @@ def test_flag_transform() -> None:
     assert "final" not in func.decorators
 
 
+def test_runtime_checkable_transform() -> None:
+    code = """
+    from typing import Protocol, runtime_checkable
+
+    class P(Protocol):
+        def run(self) -> int: ...
+
+    P = runtime_checkable(P)
+    """
+    mod = mod_from_code(code, "runtime")
+    mi = scan_module(mod)
+    prune_protocol_methods(mi)
+    cls = next(s for s in mi.symbols if isinstance(s, ClassSymbol) and s.name == "P")
+    assert "runtime_checkable" in cls.decorators
+
+
 def test_foreign_symbol_transform() -> None:
     code = """
 


### PR DESCRIPTION
## Summary
- add runtime_checkable decorator handling to protocol transformer
- include prune_protocol_methods in module pipeline
- ensure emit collects typing decorator names
- test runtime_checkable handling and update annotations

## Testing
- `python -m macrotype tests/annotations.py -o tests/annotations.pyi`
- `ruff format macrotype tests`
- `ruff check --fix macrotype tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d61aa4f848329b621ae2df8d93247