### PR TITLE
Refactor alias handling to store original typing objects

### DIFF
--- a/__macrotype__/macrotype/modules/emit.pyi
+++ b/__macrotype__/macrotype/modules/emit.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype macrotype/modules/emit.py -o __macrotype__/macrotype/emit.pyi
+# Generated via: macrotype macrotype/modules/emit.py -o __macrotype__/macrotype/modules/emit.pyi
 # Do not edit by hand
 from collections.abc import Iterable
 from macrotype.modules.scanner import ModuleInfo

--- a/__macrotype__/macrotype/modules/symbols.pyi
+++ b/__macrotype__/macrotype/modules/symbols.pyi
@@ -46,4 +46,4 @@ class ClassSymbol(Symbol):
 class AliasSymbol(Symbol):
     value: None | Site
     type_params: tuple[str, ...]
-    flags: dict[str, bool]
+    alias_type: None | object

--- a/__macrotype__/macrotype/modules/transformers/alias.pyi
+++ b/__macrotype__/macrotype/modules/transformers/alias.pyi
@@ -1,3 +1,5 @@
+# Generated via: macrotype macrotype/modules/transformers/alias.py -o __macrotype__/macrotype/modules/transformers/alias.pyi
+# Do not edit by hand
 from macrotype.modules.scanner import ModuleInfo
 
 def synthesize_aliases(mi: ModuleInfo) -> None: ...

--- a/__macrotype__/macrotype/symbols.pyi
+++ b/__macrotype__/macrotype/symbols.pyi
@@ -46,4 +46,4 @@ class ClassSymbol(Symbol):
 class AliasSymbol(Symbol):
     value: None | Site
     type_params: tuple[str, ...]
-    flags: dict[str, bool]
+    alias_type: None | object

--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -58,15 +58,16 @@ def _collect_typing_names(symbols: Iterable[Symbol]) -> set[str]:
             if base in {"final", "override", "overload", "runtime_checkable"}:
                 names.add(base)
         match sym:
-            case AliasSymbol(flags=flags):
-                if flags.get("is_typevar"):
-                    names.add("TypeVar")
-                if flags.get("is_paramspec"):
-                    names.add("ParamSpec")
-                if flags.get("is_typevartuple"):
-                    names.add("TypeVarTuple")
-                if flags.get("is_newtype"):
-                    names.add("NewType")
+            case AliasSymbol(alias_type=alias):
+                match alias:
+                    case t.TypeVar():
+                        names.add("TypeVar")
+                    case t.ParamSpec():
+                        names.add("ParamSpec")
+                    case t.TypeVarTuple():
+                        names.add("TypeVarTuple")
+                    case _ if callable(alias) and hasattr(alias, "__supertype__"):
+                        names.add("NewType")
             case ClassSymbol(members=members):
                 names.update(_collect_typing_names(members))
     return names
@@ -221,23 +222,28 @@ def _emit_symbol(sym: Symbol, name_map: dict[int, str], *, indent: int) -> list[
             line = _add_comment(line, sym.comment or site.comment)
             return [line]
 
-        case AliasSymbol(value=site, type_params=params, flags=flags):
-            if flags.get("is_typevar"):
-                line = f"{pad}{sym.name} = {_stringify_typevar(site.annotation, name_map)}"
-            elif flags.get("is_paramspec"):
-                line = f"{pad}{sym.name} = {_stringify_paramspec(site.annotation)}"
-            elif flags.get("is_typevartuple"):
-                line = f"{pad}{sym.name} = {_stringify_typevartuple(site.annotation)}"
-            elif flags.get("is_newtype"):
-                ty = stringify_annotation(site.annotation, name_map)
-                line = f'{pad}{sym.name} = NewType("{sym.name}", {ty})'
-            elif flags.get("is_typealias"):
-                ty = stringify_annotation(site.annotation, name_map)
-                line = f"{pad}{sym.name} = {ty}"
-            else:
-                ty = stringify_annotation(site.annotation, name_map)
-                param_str = f"[{', '.join(params)}]" if params else ""
-                line = f"{pad}type {sym.name}{param_str} = {ty}"
+        case AliasSymbol(value=site, type_params=params, alias_type=alias):
+            match alias:
+                case t.TypeVar():
+                    line = f"{pad}{sym.name} = {_stringify_typevar(alias, name_map)}"
+                case t.ParamSpec():
+                    line = f"{pad}{sym.name} = {_stringify_paramspec(alias)}"
+                case t.TypeVarTuple():
+                    line = f"{pad}{sym.name} = {_stringify_typevartuple(alias)}"
+                case t.TypeAlias:  # type: ignore[misc]
+                    ty = stringify_annotation(site.annotation, name_map)
+                    line = f"{pad}{sym.name} = {ty}"
+                case _ if callable(alias) and hasattr(alias, "__supertype__"):
+                    ty = stringify_annotation(site.annotation, name_map)
+                    line = f'{pad}{sym.name} = NewType("{sym.name}", {ty})'
+                case t.TypeAliasType():  # type: ignore[attr-defined]
+                    ty = stringify_annotation(site.annotation, name_map)
+                    param_str = f"[{', '.join(params)}]" if params else ""
+                    line = f"{pad}type {sym.name}{param_str} = {ty}"
+                case _:
+                    ty = stringify_annotation(site.annotation, name_map)
+                    param_str = f"[{', '.join(params)}]" if params else ""
+                    line = f"{pad}type {sym.name}{param_str} = {ty}"
             line = _add_comment(line, sym.comment or site.comment)
             return [line]
 

--- a/macrotype/modules/symbols.py
+++ b/macrotype/modules/symbols.py
@@ -53,4 +53,4 @@ class ClassSymbol(Symbol):
 class AliasSymbol(Symbol):
     value: Optional[Site]
     type_params: tuple[str, ...] = ()
-    flags: dict[str, bool] = field(default_factory=dict)
+    alias_type: object | None = None

--- a/macrotype/modules/transformers/alias.py
+++ b/macrotype/modules/transformers/alias.py
@@ -16,6 +16,7 @@ def synthesize_aliases(mi: ModuleInfo) -> None:
         obj = glb.get(sym.name)
         if isinstance(obj, t.TypeAliasType):  # type: ignore[attr-defined]
             sym.value = Site(role="alias_value", annotation=obj.__value__)
+            sym.alias_type = obj
             params: list[str] = []
             for tp in getattr(obj, "__type_params__", ()):  # pragma: no cover - py312+
                 if glb.get(tp.__name__) is tp:
@@ -29,10 +30,10 @@ def synthesize_aliases(mi: ModuleInfo) -> None:
                     params.append(tp.__name__)
             sym.type_params = tuple(params)
         if annotations.get(sym.name) is t.TypeAlias:
-            sym.flags["is_typealias"] = True
+            sym.alias_type = t.TypeAlias
         if isinstance(obj, t.TypeVar):
-            sym.flags["is_typevar"] = True
+            sym.alias_type = obj
         elif isinstance(obj, t.ParamSpec):
-            sym.flags["is_paramspec"] = True
+            sym.alias_type = obj
         elif isinstance(obj, t.TypeVarTuple):
-            sym.flags["is_typevartuple"] = True
+            sym.alias_type = obj

--- a/macrotype/modules/transformers/alias.py
+++ b/macrotype/modules/transformers/alias.py
@@ -29,11 +29,7 @@ def synthesize_aliases(mi: ModuleInfo) -> None:
                 else:
                     params.append(tp.__name__)
             sym.type_params = tuple(params)
-        if annotations.get(sym.name) is t.TypeAlias:
+        elif annotations.get(sym.name) is t.TypeAlias:
             sym.alias_type = t.TypeAlias
-        if isinstance(obj, t.TypeVar):
-            sym.alias_type = obj
-        elif isinstance(obj, t.ParamSpec):
-            sym.alias_type = obj
-        elif isinstance(obj, t.TypeVarTuple):
+        elif isinstance(obj, (t.TypeVar, t.ParamSpec, t.TypeVarTuple)):
             sym.alias_type = obj

--- a/macrotype/modules/transformers/newtype.py
+++ b/macrotype/modules/transformers/newtype.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Convert typing.NewType functions into alias symbols."""
 
+import typing as t
 from typing import Any
 
 from macrotype.modules.scanner import ModuleInfo
@@ -25,7 +26,7 @@ def _transform_symbols(symbols: list[Symbol], namespace: dict[str, Any]) -> list
                     alias = AliasSymbol(
                         name=name,
                         value=Site(role="alias_value", annotation=obj.__supertype__),
-                        alias_type=obj,
+                        alias_type=t.NewType,
                         comment=comment,
                         emit=emit,
                     )
@@ -38,7 +39,7 @@ def _transform_symbols(symbols: list[Symbol], namespace: dict[str, Any]) -> list
                     alias = AliasSymbol(
                         name=name,
                         value=Site(role="alias_value", annotation=obj.__supertype__),
-                        alias_type=obj,
+                        alias_type=t.NewType,
                         comment=comment,
                         emit=emit,
                     )

--- a/macrotype/modules/transformers/newtype.py
+++ b/macrotype/modules/transformers/newtype.py
@@ -25,7 +25,7 @@ def _transform_symbols(symbols: list[Symbol], namespace: dict[str, Any]) -> list
                     alias = AliasSymbol(
                         name=name,
                         value=Site(role="alias_value", annotation=obj.__supertype__),
-                        flags={"is_newtype": True},
+                        alias_type=obj,
                         comment=comment,
                         emit=emit,
                     )
@@ -38,7 +38,7 @@ def _transform_symbols(symbols: list[Symbol], namespace: dict[str, Any]) -> list
                     alias = AliasSymbol(
                         name=name,
                         value=Site(role="alias_value", annotation=obj.__supertype__),
-                        flags={"is_newtype": True},
+                        alias_type=obj,
                         comment=comment,
                         emit=emit,
                     )

--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -171,7 +171,7 @@ case8 = (
             AliasSymbol(
                 name="UserId",
                 value=Site(role="alias_value", annotation=int),
-                alias_type=NewType("UserId", int),
+                alias_type=NewType,
             ),
         ],
     ),

--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import ModuleType
-from typing import Annotated, Any, Callable, ClassVar, Literal, Union
+from typing import Annotated, Any, Callable, ClassVar, Literal, NewType, TypeAliasType, Union
 
 from macrotype.modules.emit import emit_module
 from macrotype.modules.scanner import ModuleInfo
@@ -28,6 +28,7 @@ case2 = (
             AliasSymbol(
                 name="Alias",
                 value=Site(role="alias_value", annotation=list[int]),
+                alias_type=TypeAliasType("Alias", list[int]),
             ),
             FuncSymbol(
                 name="f",
@@ -170,7 +171,7 @@ case8 = (
             AliasSymbol(
                 name="UserId",
                 value=Site(role="alias_value", annotation=int),
-                flags={"is_newtype": True},
+                alias_type=NewType("UserId", int),
             ),
         ],
     ),

--- a/tests/modules/transformers/test_transformers.py
+++ b/tests/modules/transformers/test_transformers.py
@@ -86,7 +86,7 @@ def test_newtype_transform() -> None:
     by_name = {s.name: s for s in mi.symbols}
     user = by_name["UserId"]
     assert isinstance(user, AliasSymbol)
-    assert user.alias_type and hasattr(user.alias_type, "__supertype__")
+    assert user.alias_type is t.NewType
     assert user.value and user.value.annotation is int
 
 

--- a/tests/modules/transformers/test_transformers.py
+++ b/tests/modules/transformers/test_transformers.py
@@ -86,7 +86,7 @@ def test_newtype_transform() -> None:
     by_name = {s.name: s for s in mi.symbols}
     user = by_name["UserId"]
     assert isinstance(user, AliasSymbol)
-    assert user.flags.get("is_newtype") is True
+    assert user.alias_type and hasattr(user.alias_type, "__supertype__")
     assert user.value and user.value.annotation is int
 
 


### PR DESCRIPTION
## Summary
- track alias kind by storing the original typing object on `AliasSymbol`
- emit aliases by pattern matching on that object instead of boolean flags
- adjust transformers and tests to use the new `alias_type` attribute

## Testing
- `ruff format`
- `ruff check --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d677467488329b7b531172a0dbede