### PR TITLE
Prune explicit Protocol hooks

### DIFF
--- a/__macrotype__/macrotype/modules/transformers/protocol.pyi
+++ b/__macrotype__/macrotype/modules/transformers/protocol.pyi
@@ -1,0 +1,6 @@
+from typing import Any
+
+from macrotype.modules.ir import ClassDecl, ModuleDecl
+
+def _transform_class(sym: ClassDecl, cls: type[Any]) -> None: ...
+def prune_protocol_methods(mi: ModuleDecl) -> None: ...

--- a/macrotype/modules/transformers/protocol.py
+++ b/macrotype/modules/transformers/protocol.py
@@ -6,8 +6,14 @@ from typing import Any
 
 from macrotype.modules.ir import ClassDecl, FuncDecl, ModuleDecl
 
-# Methods inserted by ``Protocol`` machinery which should be removed
-_PROTOCOL_METHOD_NAMES = {"_proto_hook", "_no_init_or_replace_init"}
+# Methods inserted by ``Protocol`` machinery or otherwise disallowed
+# on ``Protocol`` classes which should be removed from stubs.
+_PROTOCOL_METHOD_NAMES = {
+    "_proto_hook",
+    "_no_init_or_replace_init",
+    "__init__",
+    "__subclasshook__",
+}
 
 
 def _transform_class(sym: ClassDecl, cls: type[Any]) -> None:

--- a/tests/modules/transformers/test_transformers.py
+++ b/tests/modules/transformers/test_transformers.py
@@ -314,6 +314,26 @@ def test_protocol_transform() -> None:
     assert member_names == {"meth"}
 
 
+def test_protocol_prunes_explicit_methods() -> None:
+    code = """
+    from typing import Protocol
+
+    class P(Protocol):
+        def __init__(self, x: int) -> None: ...
+        @classmethod
+        def __subclasshook__(cls, other: type) -> bool: ...
+        def meth(self) -> None: ...
+    """
+    mod = mod_from_code(code, "proto_explicit")
+    mi = scan_module(mod)
+    prune_protocol_methods(mi)
+    proto = t.cast(
+        ClassDecl, next(s for s in mi.members if isinstance(s, ClassDecl) and s.name == "P")
+    )
+    member_names = {m.name for m in proto.members if isinstance(m, FuncDecl)}
+    assert member_names == {"meth"}
+
+
 @pytest.mark.skip(reason="TypedDict base classes not in MRO at runtime")
 def test_typeddict_transform() -> None:
     code = """


### PR DESCRIPTION
## Summary
- Strip `__init__` and `__subclasshook__` from Protocol stubs
- Add regression test for pruning explicit Protocol methods

## Testing
- `ruff format macrotype/modules/transformers/protocol.py tests/modules/transformers/test_transformers.py __macrotype__/macrotype/modules/transformers/protocol.pyi`
- `ruff check --fix macrotype/modules/transformers/protocol.py tests/modules/transformers/test_transformers.py __macrotype__/macrotype/modules/transformers/protocol.pyi`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d8b84738483298b4c9ac91c5a20c0