### PR TITLE
feat: infer param types from defaults

### DIFF
--- a/__macrotype__/macrotype/modules/emit.pyi
+++ b/__macrotype__/macrotype/modules/emit.pyi
@@ -1,3 +1,5 @@
+# Generated via: macrotype macrotype/modules/emit.py -o __macrotype__/macrotype/modules/emit.pyi
+# Do not edit by hand
 from collections.abc import Callable, Iterable
 from typing import Any, ParamSpec, TypeVar, TypeVarTuple
 

--- a/__macrotype__/macrotype/modules/transformers/__init__.pyi
+++ b/__macrotype__/macrotype/modules/transformers/__init__.pyi
@@ -1,2 +1,33 @@
 # Generated via: macrotype macrotype/modules/transformers/__init__.py -o __macrotype__/macrotype/modules/transformers/__init__.pyi
 # Do not edit by hand
+from .add_comment import add_comments
+from .alias import synthesize_aliases
+from .dataclass import transform_dataclasses
+from .decorator import unwrap_decorated_functions
+from .descriptor import normalize_descriptors
+from .enum import transform_enums
+from .flag import normalize_flags
+from .foreign_symbol import canonicalize_foreign_symbols
+from .namedtuple import transform_namedtuples
+from .newtype import transform_newtypes
+from .overload import expand_overloads
+from .param_default import infer_param_defaults
+from .protocol import prune_protocol_methods
+from .typeddict import prune_inherited_typeddict_fields
+
+__all__ = [
+    "add_comments",
+    "synthesize_aliases",
+    "transform_dataclasses",
+    "normalize_descriptors",
+    "transform_enums",
+    "normalize_flags",
+    "canonicalize_foreign_symbols",
+    "expand_overloads",
+    "transform_newtypes",
+    "infer_param_defaults",
+    "prune_protocol_methods",
+    "prune_inherited_typeddict_fields",
+    "transform_namedtuples",
+    "unwrap_decorated_functions",
+]

--- a/__macrotype__/macrotype/modules/transformers/param_default.pyi
+++ b/__macrotype__/macrotype/modules/transformers/param_default.pyi
@@ -1,0 +1,9 @@
+# Generated via: macrotype macrotype/modules/transformers/param_default.py -o __macrotype__/macrotype/modules/transformers/param_default.pyi
+# Do not edit by hand
+from typing import Any, Callable
+
+from macrotype.modules.ir import ClassDecl, FuncDecl, ModuleDecl
+
+def _infer_function(sym: FuncDecl, fn: Callable[..., Any]) -> None: ...
+def _transform_class(sym: ClassDecl, cls: type) -> None: ...
+def infer_param_defaults(mi: ModuleDecl) -> None: ...

--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -231,9 +231,16 @@ def _emit_decl(sym: Decl, name_map: dict[int, str], *, indent: int) -> list[str]
             pieces: list[str] = []
             for d in decos:
                 pieces.append(f"{pad}@{d}")
-            param_strs = [
-                f"{p.name}: {stringify_annotation(p.annotation, name_map)}" for p in params
-            ]
+            param_strs: list[str] = []
+            for p in params:
+                name = p.name or ""
+                if name in {"*", "/"}:
+                    param_strs.append(name)
+                    continue
+                if p.annotation is None:
+                    param_strs.append(name)
+                else:
+                    param_strs.append(f"{name}: {stringify_annotation(p.annotation, name_map)}")
             ret_str = f" -> {stringify_annotation(ret.annotation, name_map)}" if ret else ""
             line = f"{pad}def {sym.name}({', '.join(param_strs)}){ret_str}: ..."
             line = _add_comment(line, sym.comment)

--- a/macrotype/modules/transformers/__init__.py
+++ b/macrotype/modules/transformers/__init__.py
@@ -9,6 +9,7 @@ from .foreign_symbol import canonicalize_foreign_symbols
 from .namedtuple import transform_namedtuples
 from .newtype import transform_newtypes
 from .overload import expand_overloads
+from .param_default import infer_param_defaults
 from .protocol import prune_protocol_methods
 from .typeddict import prune_inherited_typeddict_fields
 
@@ -22,6 +23,7 @@ __all__ = [
     "canonicalize_foreign_symbols",
     "expand_overloads",
     "transform_newtypes",
+    "infer_param_defaults",
     "prune_protocol_methods",
     "prune_inherited_typeddict_fields",
     "transform_namedtuples",

--- a/macrotype/modules/transformers/param_default.py
+++ b/macrotype/modules/transformers/param_default.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Infer parameter types from default values."""
+
+import inspect
+from typing import Callable
+
+from macrotype.modules.ir import ClassDecl, FuncDecl, ModuleDecl, Site
+
+
+def _infer_function(sym: FuncDecl, fn: Callable) -> None:
+    sig = inspect.signature(fn)
+    existing = {p.name.lstrip("*"): p for p in sym.params}
+    new_params: list[Site] = []
+    for p in sig.parameters.values():
+        name = p.name
+        if p.kind is inspect.Parameter.VAR_POSITIONAL:
+            display = f"*{name}"
+        elif p.kind is inspect.Parameter.VAR_KEYWORD:
+            display = f"**{name}"
+        else:
+            display = name
+        site = existing.get(name)
+        if site is not None:
+            if site.name != display:
+                site = Site(role="param", name=display, annotation=site.annotation)
+        else:
+            ann = None
+            if (
+                p.default is not inspect._empty
+                and p.default is not None
+                and name not in {"self", "cls"}
+            ):
+                ann = type(p.default)
+            site = Site(role="param", name=display, annotation=ann)
+        new_params.append(site)
+    sym.params = tuple(new_params)
+
+
+def _transform_class(sym: ClassDecl, cls: type) -> None:
+    for m in sym.members:
+        if isinstance(m, FuncDecl):
+            fn = m.obj
+            if callable(fn):
+                _infer_function(m, fn)
+        elif isinstance(m, ClassDecl):
+            inner = m.obj
+            if isinstance(inner, type):
+                _transform_class(m, inner)
+
+
+def infer_param_defaults(mi: ModuleDecl) -> None:
+    """Infer parameter types from default values within ``mi``."""
+    for sym in mi.members:
+        if isinstance(sym, FuncDecl):
+            fn = sym.obj
+            if callable(fn):
+                _infer_function(sym, fn)
+        elif isinstance(sym, ClassDecl):
+            cls = sym.obj
+            if isinstance(cls, type):
+                _transform_class(sym, cls)


### PR DESCRIPTION
## Summary
- infer function parameter types from default values via new transformer
- emit unannotated parameters correctly
- test parameter-default inference

## Testing
- `ruff format macrotype/modules/transformers/param_default.py macrotype/modules/emit.py macrotype/modules/transformers/__init__.py tests/modules/transformers/test_transformers.py __macrotype__/macrotype/modules/emit.pyi __macrotype__/macrotype/modules/transformers/param_default.pyi __macrotype__/macrotype/modules/transformers/__init__.pyi`
- `ruff check --fix macrotype/modules/transformers/param_default.py macrotype/modules/emit.py macrotype/modules/transformers/__init__.py tests/modules/transformers/test_transformers.py __macrotype__/macrotype/modules/emit.pyi __macrotype__/macrotype/modules/transformers/param_default.pyi __macrotype__/macrotype/modules/transformers/__init__.pyi`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d8d70ef188329ad1906d5a74aab1b