### PR TITLE
Support Generic type parameter extraction in module transformers

### DIFF
--- a/__macrotype__/macrotype/modules/ir.pyi
+++ b/__macrotype__/macrotype/modules/ir.pyi
@@ -50,6 +50,7 @@ class ClassDecl(Decl):
     obj: None | object
     decorators: tuple[str, ...]
     flags: dict[str, bool]
+    type_params: tuple[str, ...]
     def get_children(self) -> tuple[Decl, ...]: ...
     def get_annotation_sites(self) -> tuple[Site, ...]: ...
 

--- a/__macrotype__/macrotype/modules/transformers/__init__.pyi
+++ b/__macrotype__/macrotype/modules/transformers/__init__.pyi
@@ -14,6 +14,7 @@ from .overload import expand_overloads
 from .param_default import infer_param_defaults
 from .protocol import prune_protocol_methods
 from .typeddict import prune_inherited_typeddict_fields
+from .generic import transform_generics
 
 __all__ = [
     "add_comments",
@@ -29,5 +30,6 @@ __all__ = [
     "prune_protocol_methods",
     "prune_inherited_typeddict_fields",
     "transform_namedtuples",
+    "transform_generics",
     "unwrap_decorated_functions",
 ]

--- a/__macrotype__/macrotype/modules/transformers/generic.pyi
+++ b/__macrotype__/macrotype/modules/transformers/generic.pyi
@@ -1,0 +1,3 @@
+from macrotype.modules.ir import ModuleDecl
+
+def transform_generics(mi: ModuleDecl) -> None: ...

--- a/macrotype/modules/__init__.py
+++ b/macrotype/modules/__init__.py
@@ -16,6 +16,7 @@ __all__ = [
     "normalize_flags",
     "normalize_descriptors",
     "canonicalize_foreign_symbols",
+    "transform_generics",
     "synthesize_aliases",
     "prune_inherited_typeddict_fields",
     "prune_protocol_methods",
@@ -29,6 +30,7 @@ def __getattr__(name: str):
     if name in {
         "add_comments",
         "canonicalize_foreign_symbols",
+        "transform_generics",
         "expand_overloads",
         "normalize_descriptors",
         "normalize_flags",
@@ -51,6 +53,7 @@ def from_module(mod: ModuleType) -> ModuleDecl:
     mi = scan_module(mod)
     _t.canonicalize_foreign_symbols(mi)
     _t.synthesize_aliases(mi)
+    _t.transform_generics(mi)
     _t.transform_dataclasses(mi)
     _t.prune_inherited_typeddict_fields(mi)
     _t.normalize_descriptors(mi)

--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -247,14 +247,21 @@ def _emit_decl(sym: Decl, name_map: dict[int, str], *, indent: int) -> list[str]
             pieces.append(line)
             return pieces
 
-        case ClassDecl(bases=bases, td_fields=fields, members=members, decorators=decos):
+        case ClassDecl(
+            bases=bases,
+            td_fields=fields,
+            members=members,
+            decorators=decos,
+            type_params=tp,
+        ):
             base_str = ""
             if bases:
                 base_str = (
                     f"({', '.join(stringify_annotation(b.annotation, name_map) for b in bases)})"
                 )
+            tp_str = f"[{', '.join(tp)}]" if tp else ""
             lines = [f"{pad}@{d}" for d in decos]
-            first = f"{pad}class {sym.name}{base_str}:"
+            first = f"{pad}class {sym.name}{tp_str}{base_str}:"
             first = _add_comment(first, sym.comment)
             lines.append(first)
             if fields:

--- a/macrotype/modules/ir.py
+++ b/macrotype/modules/ir.py
@@ -70,6 +70,7 @@ class ClassDecl(Decl):
     obj: object | None = None
     decorators: tuple[str, ...] = ()
     flags: dict[str, bool] = field(default_factory=dict)  # e.g., protocol, abstract
+    type_params: tuple[str, ...] = ()
 
     def get_children(self) -> tuple[Decl, ...]:
         return self.members

--- a/macrotype/modules/transformers/__init__.py
+++ b/macrotype/modules/transformers/__init__.py
@@ -6,6 +6,7 @@ from .descriptor import normalize_descriptors
 from .enum import transform_enums
 from .flag import normalize_flags
 from .foreign_symbol import canonicalize_foreign_symbols
+from .generic import transform_generics
 from .namedtuple import transform_namedtuples
 from .newtype import transform_newtypes
 from .overload import expand_overloads
@@ -27,5 +28,6 @@ __all__ = [
     "prune_protocol_methods",
     "prune_inherited_typeddict_fields",
     "transform_namedtuples",
+    "transform_generics",
     "unwrap_decorated_functions",
 ]

--- a/macrotype/modules/transformers/generic.py
+++ b/macrotype/modules/transformers/generic.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Extract class type parameters from ``typing.Generic`` bases."""
+
+import typing as t
+from typing import get_args, get_origin
+
+from macrotype.modules.ir import ClassDecl, ModuleDecl, Site
+
+
+def _format_type_param(param: t.Any) -> str:
+    origin = get_origin(param)
+    if origin is t.Unpack:
+        (inner,) = get_args(param)
+        if isinstance(inner, t.TypeVarTuple):
+            return f"*{inner.__name__}"
+        if isinstance(inner, t.ParamSpec):
+            return f"**{inner.__name__}"
+        if isinstance(inner, t.TypeVar):
+            return f"*{inner.__name__}"
+        return f"*{getattr(inner, '__name__', repr(inner))}"
+    if isinstance(param, t.TypeVarTuple):
+        return f"*{param.__name__}"
+    if isinstance(param, t.ParamSpec):
+        return f"**{param.__name__}"
+    if isinstance(param, t.TypeVar):
+        return param.__name__
+    return getattr(param, "__name__", repr(param))
+
+
+def _transform_class(sym: ClassDecl, cls: type) -> None:
+    type_params: list[str] = []
+    new_bases: list[Site] = []
+    for b in sym.bases:
+        ann = b.annotation
+        if get_origin(ann) is t.Generic:
+            for param in get_args(ann):
+                type_params.append(_format_type_param(param))
+            continue
+        new_bases.append(b)
+
+    if type_params:
+        sym.type_params = tuple(type_params)
+        sym.bases = tuple(new_bases)
+
+    for m in sym.members:
+        if isinstance(m, ClassDecl):
+            inner = m.obj
+            if isinstance(inner, type):
+                _transform_class(m, inner)
+
+
+def transform_generics(mi: ModuleDecl) -> None:
+    """Attach class type parameters found in ``Generic`` bases."""
+
+    for sym in mi.get_all_decls():
+        if isinstance(sym, ClassDecl):
+            cls = sym.obj
+            if isinstance(cls, type):
+                _transform_class(sym, cls)


### PR DESCRIPTION
## Summary
- extract class type parameters from `typing.Generic` bases
- represent type parameters in the module IR and emitted stubs
- test generic class handling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d92e7701083299f132d3fda9d72ee