### PR TITLE
Include final decorator on functions

### DIFF
--- a/macrotype/modules/transformers/flag.py
+++ b/macrotype/modules/transformers/flag.py
@@ -16,12 +16,10 @@ def _normalize_function(sym: FuncDecl, fn: Any, *, is_method: bool) -> None:
 
     if getattr(fn, "__final__", False):
         flags["final"] = True
-        if is_method:
-            decos.append("final")
+        decos.append("final")
     if getattr(fn, "__override__", False):
         flags["override"] = True
-        if is_method:
-            decos.append("override")
+        decos.append("override")
     if getattr(fn, "__isabstractmethod__", False):
         flags["abstract"] = True
         if is_method:
@@ -33,7 +31,7 @@ def _normalize_function(sym: FuncDecl, fn: Any, *, is_method: bool) -> None:
         base = deco.split(".")[-1]
         if base == "final":
             flags["final"] = True
-            if is_method and base not in seen:
+            if base not in seen:
                 norm.append("final")
                 seen.add("final")
         elif base == "override":

--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -1231,7 +1231,7 @@ class _ModuleBuilder:
         else:
             func = PyiFunction.from_function(
                 fn_obj,
-                skip_final=True,
+                skip_final=False,
                 globalns=self.globals,
                 localns=self.globals,
             )

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -401,6 +401,7 @@ class HasFinalMethod:
     @final
     def do_final(self) -> None: ...
 
+@final
 def final_func(x: int) -> int: ...
 
 def pragma_func(x: int) -> int: ...  # pyright: ignore

--- a/tests/modules/transformers/test_transformers.py
+++ b/tests/modules/transformers/test_transformers.py
@@ -216,7 +216,7 @@ def test_flag_transform() -> None:
 
     func = t.cast(FuncDecl, by_name["f"])
     assert func.flags.get("final") is True
-    assert "final" not in func.decorators
+    assert "final" in func.decorators
 
 
 def test_runtime_checkable_transform() -> None:


### PR DESCRIPTION
## Summary
- ensure `@final` functions keep their decorator in stubs
- normalize flags transformer attaches final/override decorators to any function
- cover final functions in transformer unit tests

## Testing
- `ruff check --fix macrotype/modules/transformers/flag.py macrotype/pyi_extract.py tests/modules/transformers/test_transformers.py`
- `pytest tests/modules/transformers/test_transformers.py::test_flag_transform -q`
- `pytest tests/test_all.py::test_stub_generation_matches_expected -q`


------
https://chatgpt.com/codex/tasks/task_e_689e1b496f3c8329bc65e5a064c7a4a8