### PR TITLE
feat: infer types for unannotated constants

### DIFF
--- a/__macrotype__/macrotype/modules/transformers/__init__.pyi
+++ b/__macrotype__/macrotype/modules/transformers/__init__.pyi
@@ -2,6 +2,7 @@
 # Do not edit by hand
 from .add_comment import add_comments
 from .alias import synthesize_aliases
+from .constant import infer_constant_types
 from .dataclass import transform_dataclasses
 from .decorator import unwrap_decorated_functions
 from .descriptor import normalize_descriptors
@@ -19,6 +20,7 @@ from .generic import transform_generics
 __all__ = [
     "add_comments",
     "synthesize_aliases",
+    "infer_constant_types",
     "transform_dataclasses",
     "normalize_descriptors",
     "transform_enums",

--- a/__macrotype__/macrotype/modules/transformers/constant.pyi
+++ b/__macrotype__/macrotype/modules/transformers/constant.pyi
@@ -1,0 +1,5 @@
+# Generated via: macrotype macrotype/modules/transformers/constant.py -o __macrotype__/macrotype/modules/transformers/constant.pyi
+# Do not edit by hand
+from macrotype.modules.ir import ModuleDecl
+
+def infer_constant_types(mi: ModuleDecl) -> None: ...

--- a/macrotype/modules/transformers/__init__.py
+++ b/macrotype/modules/transformers/__init__.py
@@ -1,5 +1,6 @@
 from .add_comment import add_comments
 from .alias import synthesize_aliases
+from .constant import infer_constant_types
 from .dataclass import transform_dataclasses
 from .decorator import unwrap_decorated_functions
 from .descriptor import normalize_descriptors
@@ -17,6 +18,7 @@ from .typeddict import prune_inherited_typeddict_fields
 __all__ = [
     "add_comments",
     "synthesize_aliases",
+    "infer_constant_types",
     "transform_dataclasses",
     "normalize_descriptors",
     "transform_enums",

--- a/macrotype/modules/transformers/constant.py
+++ b/macrotype/modules/transformers/constant.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from macrotype.modules.ir import ModuleDecl, VarDecl
+
+
+def infer_constant_types(mi: ModuleDecl) -> None:
+    """Populate missing annotations for simple constant assignments."""
+    for decl in mi.get_all_decls():
+        if not isinstance(decl, VarDecl):
+            continue
+        site = decl.site
+        if site.annotation is not None:
+            continue
+        obj = decl.obj
+        if obj is None:
+            continue
+        ty = type(obj)
+        if ty in {bool, int, float, str}:
+            site.annotation = ty

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -128,6 +128,18 @@ BORDER_SIZE: Final = 4
 
 # Edge case: unannotated constant should be included
 UNANNOTATED_CONST = 42
+# Edge case: unannotated string constant should be included
+UNANNOTATED_STR = "hi"
+# Edge case: unannotated float constant should be included
+UNANNOTATED_FLOAT = 1.23
+
+
+# Edge case: subclass constants should preserve subclass type
+class CustomInt(int):
+    pass
+
+
+UNANNOTATED_CUSTOM_INT = CustomInt(7)
 
 # Edge case: boolean constants should be retained
 BOOL_TRUE = True

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -105,6 +105,14 @@ BORDER_SIZE: Final[int]
 
 UNANNOTATED_CONST: int
 
+UNANNOTATED_STR: str
+
+UNANNOTATED_FLOAT: float
+
+class CustomInt(int): ...
+
+UNANNOTATED_CUSTOM_INT: CustomInt
+
 BOOL_TRUE: bool
 
 BOOL_FALSE: bool


### PR DESCRIPTION
## Summary
- infer types for int/str/float/bool constants without annotations
- test constant inference in transformer suite
- exercise new constant inference in annotations samples

## Testing
- `python -m macrotype macrotype/modules/transformers/constant.py -o __macrotype__/macrotype/modules/transformers/constant.pyi`
- `python -m macrotype tests/annotations.py -o tests/annotations.pyi`
- `ruff format macrotype/modules/transformers/constant.py tests/modules/transformers/test_transformers.py tests/annotations.py __macrotype__/macrotype/modules/transformers/constant.pyi`
- `ruff check --fix macrotype/modules/transformers/constant.py tests/modules/transformers/test_transformers.py tests/annotations.py __macrotype__/macrotype/modules/transformers/constant.pyi`
- `pytest tests/modules/transformers/test_transformers.py::test_constant_transform tests/test_all.py::test_stub_generation_matches_expected -q`


------
https://chatgpt.com/codex/tasks/task_e_689e30681dbc8329b002009daa977a9a