### PR TITLE
feat: add external import alias handling

### DIFF
--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import pathlib
 from types import ModuleType
 from typing import Annotated, Any, Callable, ClassVar, Literal, NewType, TypeAliasType, Union
 
+from macrotype.meta_types import set_module
 from macrotype.modules.emit import emit_module
 from macrotype.modules.ir import (
     ClassDecl,
@@ -209,7 +211,22 @@ case9 = (
         "    ...",
     ],
 )
-CASES = [case1, case2, case3, case4, case5, case6, case7, case8, case9]
+mod10 = ModuleType("m10")
+orig = pathlib.Path.__module__
+set_module(pathlib.Path, "pathlib._local")
+case10 = (
+    ModuleDecl(
+        name=mod10.__name__,
+        obj=mod10,
+        members=[
+            VarDecl(name="p", site=Site(role="var", annotation=pathlib.Path)),
+        ],
+    ),
+    ["from pathlib import Path", "", "p: Path"],
+)
+set_module(pathlib.Path, orig)
+
+CASES = [case1, case2, case3, case4, case5, case6, case7, case8, case9, case10]
 
 
 def test_emit_module_table() -> None:


### PR DESCRIPTION
## Summary
- handle imports from external modules when emitting stubs
- support module alias mapping like pathlib._local -> pathlib
- add regression tests for module alias import

## Testing
- `ruff format macrotype/modules/emit.py tests/modules/test_emit.py`
- `ruff check --fix macrotype/modules/emit.py tests/modules/test_emit.py`
- `pytest tests/modules/test_emit.py::test_emit_module_table -q`


------
https://chatgpt.com/codex/tasks/task_e_689e36808b088329b90d996bca0f1ec1