### PR TITLE
refactor: move import resolution into transformer

### DIFF
--- a/macrotype/modules/__init__.py
+++ b/macrotype/modules/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "emit_module",
     "scan_module",
     "transform_dataclasses",
+    "resolve_imports",
 ]
 
 
@@ -38,6 +39,7 @@ def __getattr__(name: str):
         "prune_protocol_methods",
         "synthesize_aliases",
         "transform_dataclasses",
+        "resolve_imports",
     }:
         from . import transformers as _t
 
@@ -61,4 +63,5 @@ def from_module(mod: ModuleType) -> ModuleDecl:
     _t.prune_protocol_methods(mi)
     _t.expand_overloads(mi)
     _t.add_comments(mi)
+    _t.resolve_imports(mi)
     return mi

--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import types
-from collections import defaultdict
-from collections.abc import Callable as ABC_Callable
 from typing import Annotated, Any, Callable, ForwardRef, Iterable, get_args, get_origin
 
 INDENT = "    "
@@ -10,12 +8,6 @@ INDENT = "    "
 import typing as t
 
 from .ir import ClassDecl, Decl, FuncDecl, ModuleDecl, TypeDefDecl, VarDecl
-
-# Mapping of alias module names to their canonical form.
-_MODULE_ALIASES: dict[str, str] = {
-    "pathlib._local": "pathlib",
-    "pathlib._pathlib": "pathlib",
-}
 
 
 def emit_module(mi: ModuleDecl) -> list[str]:
@@ -28,28 +20,6 @@ def emit_module(mi: ModuleDecl) -> list[str]:
     context = mi.obj.__dict__
     name_map = build_name_map(atoms.values(), context)
 
-    # Precompute typing import names for later checks.
-    typing_names = {
-        name_map[id(a)]
-        for a in atoms.values()
-        if getattr(a, "__module__", None) == "typing" or a in {Callable, ABC_Callable}
-    }
-    typing_names.update(_collect_typing_names(mi.members))
-
-    # Collect imports for non-typing external modules.
-    external: dict[str, set[str]] = defaultdict(set)
-    for atom in atoms.values():
-        modname = getattr(atom, "__module__", None)
-        name = name_map.get(id(atom))
-        if not modname or not name:
-            continue
-        if name in typing_names:
-            continue
-        modname = _MODULE_ALIASES.get(modname, modname)
-        if modname in {"builtins", "typing", mi.obj.__name__}:
-            continue
-        external[modname].add(name)
-
     lines: list[str] = []
     for sym in mi.members:
         if not sym.emit:
@@ -59,39 +29,10 @@ def emit_module(mi: ModuleDecl) -> list[str]:
     if lines and lines[-1] == "":
         lines.pop()
 
-    pre: list[str] = []
-    if external:
-        for mod, names in sorted(external.items()):
-            pre.append(f"from {mod} import {', '.join(sorted(names))}")
-        if typing_names:
-            pre.append("")
-        elif lines:
-            pre.append("")
-    if typing_names:
-        pre.append(f"from typing import {', '.join(sorted(typing_names))}")
-        if lines:
-            pre.append("")
+    pre = mi.imports.lines() if mi.imports else []
+    if pre and lines:
+        return pre + [""] + lines
     return pre + lines
-
-
-def _collect_typing_names(symbols: Iterable[Decl]) -> set[str]:
-    names: set[str] = set()
-    for sym in symbols:
-        if not sym.emit:
-            continue
-        for deco in getattr(sym, "decorators", ()):  # collect decorator names from typing
-            base = deco.split("(")[0].split(".")[-1]
-            if base in {"final", "override", "overload", "runtime_checkable"}:
-                names.add(base)
-        match sym:
-            case TypeDefDecl(obj_type=alias):
-                if isinstance(alias, (t.TypeVar, t.ParamSpec, t.TypeVarTuple)):
-                    names.add(type(alias).__name__)
-                elif alias is t.NewType:
-                    names.add(alias.__name__)
-            case ClassDecl(members=members):
-                names.update(_collect_typing_names(members))
-    return names
 
 
 def _add_comment(line: str, comment: str | None) -> str:

--- a/macrotype/modules/ir.py
+++ b/macrotype/modules/ir.py
@@ -92,9 +92,26 @@ class TypeDefDecl(Decl):
 
 
 @dataclass(kw_only=True)
+class ImportBlock:
+    typing: set[str] = field(default_factory=set)
+    froms: dict[str, set[str]] = field(default_factory=dict)
+
+    def lines(self) -> list[str]:
+        lines: list[str] = []
+        for mod, names in sorted(self.froms.items()):
+            lines.append(f"from {mod} import {', '.join(sorted(names))}")
+        if self.typing:
+            if lines:
+                lines.append("")
+            lines.append(f"from typing import {', '.join(sorted(self.typing))}")
+        return lines
+
+
+@dataclass(kw_only=True)
 class ModuleDecl(Decl):
     obj: ModuleType
     members: list[Decl]
+    imports: ImportBlock = field(default_factory=ImportBlock)
 
     def get_children(self) -> tuple[Decl, ...]:
         return tuple(self.members)

--- a/macrotype/modules/transformers/__init__.py
+++ b/macrotype/modules/transformers/__init__.py
@@ -13,6 +13,7 @@ from .newtype import transform_newtypes
 from .overload import expand_overloads
 from .param_default import infer_param_defaults
 from .protocol import prune_protocol_methods
+from .resolve_imports import resolve_imports
 from .typeddict import prune_inherited_typeddict_fields
 
 __all__ = [
@@ -32,4 +33,5 @@ __all__ = [
     "transform_namedtuples",
     "transform_generics",
     "unwrap_decorated_functions",
+    "resolve_imports",
 ]

--- a/macrotype/modules/transformers/resolve_imports.py
+++ b/macrotype/modules/transformers/resolve_imports.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import typing as t
+from collections import defaultdict
+from collections.abc import Callable as ABC_Callable
+from typing import Callable, Iterable
+
+from ..emit import (
+    build_name_map,
+    collect_all_annotations,
+    flatten_annotation_atoms,
+)
+from ..ir import ClassDecl, Decl, ImportBlock, ModuleDecl, TypeDefDecl
+
+_MODULE_ALIASES: dict[str, str] = {
+    "pathlib._local": "pathlib",
+    "pathlib._pathlib": "pathlib",
+}
+
+
+def resolve_imports(mi: ModuleDecl) -> None:
+    annotations = collect_all_annotations(mi)
+    atoms: dict[int, t.Any] = {}
+    for ann in annotations:
+        atoms.update(flatten_annotation_atoms(ann))
+
+    context = mi.obj.__dict__
+    name_map = build_name_map(atoms.values(), context)
+
+    typing_names = {
+        name_map[id(a)]
+        for a in atoms.values()
+        if getattr(a, "__module__", None) == "typing" or a in {Callable, ABC_Callable}
+    }
+    typing_names.update(_collect_typing_names(mi.members))
+
+    external: dict[str, set[str]] = defaultdict(set)
+    for atom in atoms.values():
+        modname = getattr(atom, "__module__", None)
+        name = name_map.get(id(atom))
+        if not modname or not name:
+            continue
+        if name in typing_names:
+            continue
+        modname = _MODULE_ALIASES.get(modname, modname)
+        if modname in {"builtins", "typing", mi.obj.__name__}:
+            continue
+        external[modname].add(name)
+
+    mi.imports = ImportBlock(typing=typing_names, froms=dict(external))
+
+
+def _collect_typing_names(symbols: Iterable[Decl]) -> set[str]:
+    names: set[str] = set()
+    for sym in symbols:
+        if not sym.emit:
+            continue
+        for deco in getattr(sym, "decorators", ()):  # collect decorator names from typing
+            base = deco.split("(")[0].split(".")[-1]
+            if base in {"final", "override", "overload", "runtime_checkable"}:
+                names.add(base)
+        match sym:
+            case TypeDefDecl(obj_type=alias):
+                if isinstance(alias, (t.TypeVar, t.ParamSpec, t.TypeVarTuple)):
+                    names.add(type(alias).__name__)
+                elif alias is t.NewType:
+                    names.add(alias.__name__)
+            case ClassDecl(members=members):
+                names.update(_collect_typing_names(members))
+    return names

--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -5,6 +5,7 @@ from types import ModuleType
 from typing import Annotated, Any, Callable, ClassVar, Literal, NewType, TypeAliasType, Union
 
 from macrotype.meta_types import set_module
+from macrotype.modules import resolve_imports
 from macrotype.modules.emit import emit_module
 from macrotype.modules.ir import (
     ClassDecl,
@@ -230,6 +231,8 @@ CASES = [case1, case2, case3, case4, case5, case6, case7, case8, case9, case10]
 
 
 def test_emit_module_table() -> None:
+    for mi, _ in CASES:
+        resolve_imports(mi)
     got = [emit_module(mi) for mi, _ in CASES]
     expected = [exp for _, exp in CASES]
     assert got == expected


### PR DESCRIPTION
## Summary
- add ImportBlock and imports field to ModuleDecl
- refactor emit to use precomputed imports
- introduce resolve_imports transformer and wire it into pipeline

## Testing
- `ruff format macrotype/modules/ir.py macrotype/modules/emit.py macrotype/modules/transformers/resolve_imports.py macrotype/modules/__init__.py macrotype/modules/transformers/__init__.py`
- `ruff check --fix macrotype/modules/ir.py macrotype/modules/emit.py macrotype/modules/transformers/resolve_imports.py macrotype/modules/__init__.py macrotype/modules/transformers/__init__.py`
- `ruff format tests/modules/test_emit.py`
- `ruff check --fix tests/modules/test_emit.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e3bc8cd2c83299bd47c77b5a5f357