### PR TITLE
Handle local aliasing in module scanner

### DIFF
--- a/macrotype/modules/scanner.py
+++ b/macrotype/modules/scanner.py
@@ -32,11 +32,19 @@ def scan_module(mod: ModuleType) -> ModuleDecl:
             continue
 
         if inspect.isclass(obj):
-            decls.append(_scan_class(obj))
+            if obj.__name__ != name:
+                site = Site(role="alias_value", annotation=obj)
+                decls.append(TypeDefDecl(name=name, value=site, obj=obj))
+            else:
+                decls.append(_scan_class(obj))
             continue
 
         if inspect.isfunction(obj):
-            decls.append(_scan_function(obj))
+            if obj.__name__ != name:
+                site = Site(role="alias_value", annotation=obj)
+                decls.append(TypeDefDecl(name=name, value=site, obj=obj))
+            else:
+                decls.append(_scan_function(obj))
             continue
 
         if name in mod_ann:

--- a/macrotype/modules/transformers/__init__.py
+++ b/macrotype/modules/transformers/__init__.py
@@ -4,6 +4,7 @@ from .constant import infer_constant_types
 from .dataclass import transform_dataclasses
 from .decorator import unwrap_decorated_functions
 from .descriptor import normalize_descriptors
+from .duplicate import canonicalize_local_aliases
 from .enum import transform_enums
 from .flag import normalize_flags
 from .foreign_symbol import canonicalize_foreign_symbols
@@ -25,6 +26,7 @@ __all__ = [
     "transform_enums",
     "normalize_flags",
     "canonicalize_foreign_symbols",
+    "canonicalize_local_aliases",
     "expand_overloads",
     "transform_newtypes",
     "infer_param_defaults",

--- a/macrotype/modules/transformers/duplicate.py
+++ b/macrotype/modules/transformers/duplicate.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from macrotype.modules.ir import Decl, ModuleDecl, Site, TypeDefDecl
+
+
+def canonicalize_local_aliases(mi: ModuleDecl) -> None:
+    """Replace duplicate variables referencing local objects with aliases."""
+
+    modname = mi.obj.__name__
+    seen: dict[int, str] = {}
+    new_syms: list[Decl] = []
+    for sym in mi.members:
+        obj = getattr(sym, "obj", None)
+        obj_mod = getattr(obj, "__module__", None)
+        if obj is None or obj_mod != modname:
+            new_syms.append(sym)
+            continue
+        obj_id = id(obj)
+        if obj_id in seen:
+            canonical = seen[obj_id]
+            if canonical != sym.name:
+                new_syms.append(
+                    TypeDefDecl(
+                        name=sym.name,
+                        value=Site(role="alias_value", annotation=obj),
+                        obj=obj,
+                        comment=getattr(sym, "comment", None),
+                        emit=getattr(sym, "emit", True),
+                    )
+                )
+            continue
+        seen[obj_id] = sym.name
+        new_syms.append(sym)
+    mi.members = new_syms

--- a/tests/modules/transformers/test_transformers.py
+++ b/tests/modules/transformers/test_transformers.py
@@ -13,6 +13,7 @@ from macrotype.modules.scanner import scan_module
 from macrotype.modules.transformers import (
     add_comments,
     canonicalize_foreign_symbols,
+    canonicalize_local_aliases,
     expand_overloads,
     infer_constant_types,
     infer_param_defaults,
@@ -308,6 +309,25 @@ def test_foreign_symbol_transform() -> None:
     assert isinstance(const, VarDecl)
     annotated = by_name["annotated"]
     assert isinstance(annotated, VarDecl)
+
+
+def test_local_alias_transform() -> None:
+    code = """
+    def func(x: int) -> int:
+        return x
+
+    alias = func
+    """
+    mod = mod_from_code(code, "local_alias")
+    mi = scan_module(mod)
+    canonicalize_local_aliases(mi)
+    unwrap_decorated_functions(mi)
+    by_name = {s.name: s for s in mi.members}
+
+    alias = by_name["alias"]
+    assert isinstance(alias, TypeDefDecl)
+    funcs = [s for s in mi.members if isinstance(s, FuncDecl)]
+    assert len(funcs) == 1
 
 
 def test_overload_transform() -> None:


### PR DESCRIPTION
## Summary
- detect when module-level names alias local functions or classes and emit aliases
- expose `canonicalize_local_aliases` transformer for deduping repeated symbols
- add unit test for local alias handling in transformers

## Testing
- `ruff check --fix macrotype/modules/scanner.py macrotype/modules/transformers/duplicate.py macrotype/modules/transformers/__init__.py tests/modules/transformers/test_transformers.py`
- `pytest tests/modules/transformers/test_transformers.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e46f3b7e883298f401f498395359a