### PR TITLE
Invoke all transformers in module pipeline

### DIFF
--- a/macrotype/modules/__init__.py
+++ b/macrotype/modules/__init__.py
@@ -16,6 +16,12 @@ __all__ = [
     "normalize_flags",
     "normalize_descriptors",
     "canonicalize_foreign_symbols",
+    "canonicalize_local_aliases",
+    "unwrap_decorated_functions",
+    "infer_param_defaults",
+    "transform_newtypes",
+    "transform_enums",
+    "transform_namedtuples",
     "transform_generics",
     "synthesize_aliases",
     "prune_inherited_typeddict_fields",
@@ -31,6 +37,12 @@ def __getattr__(name: str):
     if name in {
         "add_comments",
         "canonicalize_foreign_symbols",
+        "canonicalize_local_aliases",
+        "unwrap_decorated_functions",
+        "infer_param_defaults",
+        "transform_newtypes",
+        "transform_enums",
+        "transform_namedtuples",
         "transform_generics",
         "expand_overloads",
         "normalize_descriptors",
@@ -58,10 +70,16 @@ def from_module(mod: ModuleType, *, strict: bool = False) -> ModuleDecl:
 
     mi = scan_module(mod)
     _t.canonicalize_foreign_symbols(mi)
+    _t.unwrap_decorated_functions(mi)
+    _t.canonicalize_local_aliases(mi)
     _t.synthesize_aliases(mi)
+    _t.transform_newtypes(mi)
+    _t.transform_enums(mi)
+    _t.transform_namedtuples(mi)
     _t.transform_generics(mi)
     _t.transform_dataclasses(mi)
     _t.prune_inherited_typeddict_fields(mi)
+    _t.infer_param_defaults(mi)
     _t.normalize_descriptors(mi)
     _t.normalize_flags(mi)
     _t.prune_protocol_methods(mi)

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -165,6 +165,28 @@ def takes_optional(x=None):
     return x
 
 
+# Duplicate local aliases should be canonicalized
+def _alias_target() -> None: ...
+
+
+PRIMARY_ALIAS = _alias_target
+SECONDARY_ALIAS = _alias_target
+
+
+# Decorated function should be unwrapped and defaults inferred
+def _wrap(fn):
+    @functools.wraps(fn)
+    def inner(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    return inner
+
+
+@_wrap
+def wrapped_with_default(x: int, y=1) -> int:
+    return x + y
+
+
 def commented_func(x: int) -> None:  # pragma: func
     pass
 

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype tests/annotations.py -o -
+# Generated via: macrotype tests/annotations.py -o tests/annotations.pyi
 # Do not edit by hand
 # pyright: basic
 from abc import ABC, abstractmethod
@@ -124,6 +124,16 @@ COMMENTED_VAR: int  # pragma: var
 def mult(a, b: int): ...
 
 def takes_optional(x): ...
+
+def _alias_target() -> None: ...
+
+PRIMARY_ALIAS = _alias_target
+
+SECONDARY_ALIAS = _alias_target
+
+def _wrap(fn): ...
+
+def wrapped_with_default(x: int, y: int) -> int: ...
 
 def commented_func(x: int) -> None: ...  # pragma: func
 
@@ -611,8 +621,6 @@ class OptionalUndefinedCls:
 class RequiredUndefinedCls:
     a: int
     b: str
-
-def _wrap(fn): ...
 
 def wrapped_callable(x: int, y: str) -> str: ...
 


### PR DESCRIPTION
## Summary
- ensure module pipeline applies local alias canonicalization, NewType, enum, namedtuple, decorated function unwrapping and parameter default inference
- add regression tests for alias canonicalization and decorator unwrapping

## Testing
- `ruff format macrotype tests`
- `ruff check --fix macrotype tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e85b1af548329ad76da9ccf6a6134