### PR TITLE
Handle dataclasses InitVar generically

### DIFF
--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pathlib
+from dataclasses import InitVar
 from types import ModuleType
 from typing import Annotated, Any, Callable, ClassVar, Literal, NewType, TypeAliasType, Union
 
@@ -227,7 +228,22 @@ case10 = (
 )
 set_module(pathlib.Path, orig)
 
-CASES = [case1, case2, case3, case4, case5, case6, case7, case8, case9, case10]
+mod11 = ModuleType("m11")
+case11 = (
+    ModuleDecl(
+        name=mod11.__name__,
+        obj=mod11,
+        members=[
+            VarDecl(
+                name="iv",
+                site=Site(role="var", annotation=InitVar[list[int]]),
+            ),
+        ],
+    ),
+    ["from dataclasses import InitVar", "", "iv: InitVar[list[int]]"],
+)
+
+CASES = [case1, case2, case3, case4, case5, case6, case7, case8, case9, case10, case11]
 
 
 def test_emit_module_table() -> None:

--- a/tests/types/test_normalize.py
+++ b/tests/types/test_normalize.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import typing as t
+from dataclasses import InitVar
 from types import EllipsisType
 
 from macrotype.types.ir import (
@@ -85,6 +86,11 @@ CASES = [
     (
         TyApp(base=b("tuple"), args=(TyApp(base=typ("List"), args=(b("int"),)),)),
         TyApp(base=b("tuple"), args=(TyApp(base=b("list"), args=(b("int"),)),)),
+    ),
+    # dataclasses.InitVar is unaffected
+    (
+        TyApp(base=TyType(type_=InitVar), args=(b("int"),)),
+        TyApp(base=TyType(type_=InitVar), args=(b("int"),)),
     ),
 ]
 

--- a/tests/types/test_parse.py
+++ b/tests/types/test_parse.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import builtins
 import enum
 import typing as t
+from dataclasses import InitVar
 from types import EllipsisType
 
 import pytest
@@ -138,6 +139,12 @@ CASES: list[tuple[object, TyRoot]] = [
     # sets
     (set[int], r(TyApp(base=b("set"), args=(b("int"),)))),
     (frozenset[str], r(TyApp(base=b("frozenset"), args=(b("str"),)))),
+    # dataclasses.InitVar
+    (InitVar[int], r(TyApp(base=TyType(type_=InitVar), args=(b("int"),)))),
+    (
+        InitVar[list[int]],
+        r(TyApp(base=TyType(type_=InitVar), args=(TyApp(base=b("list"), args=(b("int"),)),))),
+    ),
     # unions / optionals
     (t.Union[int, str], r(TyUnion(options=(b("int"), b("str"))))),
     (int | str, r(TyUnion(options=(b("int"), b("str"))))),

--- a/tests/types/test_resolve.py
+++ b/tests/types/test_resolve.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import typing as t
+from dataclasses import InitVar
 
 from macrotype.types.ir import (
     Ty,
@@ -73,6 +74,11 @@ CASES: list[tuple[object, Ty]] = [
     (
         t.Callable[..., "User"],  # noqa: F821
         TyCallable(params=..., ret=TyType(type_=User)),
+    ),
+    # 7) dataclasses.InitVar inner resolves
+    (
+        InitVar["User"],  # noqa: F821
+        TyApp(base=TyType(type_=InitVar), args=(TyType(type_=User),)),
     ),
 ]
 

--- a/tests/types/test_unparse.py
+++ b/tests/types/test_unparse.py
@@ -1,4 +1,5 @@
 import builtins
+from dataclasses import InitVar
 from types import EllipsisType
 
 from macrotype.types.ir import (
@@ -57,6 +58,19 @@ CASES: list[tuple[TyRoot, str]] = [
     (
         TyRoot(ty=TyUnpack(inner=TyTypeVarTuple(name="Ts"))),
         "typing.Unpack[Ts]",
+    ),
+    (
+        TyRoot(ty=TyApp(base=TyType(type_=InitVar), args=(b("int"),))),
+        "dataclasses.InitVar[int]",
+    ),
+    (
+        TyRoot(
+            ty=TyApp(
+                base=TyType(type_=InitVar),
+                args=(TyApp(base=b("list"), args=(b("int"),)),),
+            )
+        ),
+        "dataclasses.InitVar[list[int]]",
     ),
 ]
 

--- a/tests/types/test_validate.py
+++ b/tests/types/test_validate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import typing as t
+from dataclasses import InitVar
 from types import EllipsisType
 
 import pytest
@@ -51,6 +52,7 @@ GOOD = [
         base=b("tuple"),
         args=(TyUnpack(inner=TyTypeVarTuple(name="Ts")),),
     ),  # tuple[Unpack[Ts]]
+    TyApp(base=TyType(type_=InitVar), args=(b("int"),)),  # InitVar[int]
 ]
 
 


### PR DESCRIPTION
## Summary
- generalize origin/args detection to handle user-defined generics like dataclasses.InitVar
- parse dataclasses.InitVar without special casing
- test emitting and round-tripping InitVar annotations

## Testing
- `ruff format macrotype tests`
- `ruff check --fix macrotype tests`
- `pytest tests/modules/test_emit.py tests/types/test_parse.py tests/types/test_unparse.py tests/types/test_normalize.py tests/types/test_resolve.py tests/types/test_validate.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689f5ce8ba18832983f4206f0e482f0e