### PR TITLE
Handle explicit None annotations

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import types
 from typing import Annotated, Any, Callable, ForwardRef, Iterable, get_args, get_origin
 
@@ -48,7 +49,8 @@ def collect_all_annotations(mi: ModuleDecl) -> list[Any]:
         if not sym.emit:
             continue
         for site in sym.get_annotation_sites():
-            annos.append(site.annotation)
+            if site.annotation is not inspect._empty:
+                annos.append(site.annotation)
     return annos
 
 
@@ -214,7 +216,7 @@ def _emit_decl(sym: Decl, name_map: dict[int, str], *, indent: int) -> list[str]
                 if name in {"*", "/"}:
                     param_strs.append(name)
                     continue
-                if p.annotation is None:
+                if p.annotation is inspect._empty:
                     param_strs.append(name)
                 else:
                     param_strs.append(f"{name}: {stringify_annotation(p.annotation, name_map)}")

--- a/macrotype/modules/scanner.py
+++ b/macrotype/modules/scanner.py
@@ -57,7 +57,10 @@ def scan_module(mod: ModuleType) -> ModuleDecl:
                 decls.append(VarDecl(name=name, site=site, obj=obj))
             continue
 
-        site = Site(role="var", name=name, annotation=type(obj))
+        ann = type(obj)
+        if obj is None:
+            ann = t.Any
+        site = Site(role="var", name=name, annotation=ann)
         decls.append(VarDecl(name=name, site=site, obj=obj))
 
     for name, rann in mod_ann.items():

--- a/macrotype/modules/transformers/constant.py
+++ b/macrotype/modules/transformers/constant.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import inspect
+
 from macrotype.modules.ir import ModuleDecl, VarDecl
 
 
@@ -9,7 +11,7 @@ def infer_constant_types(mi: ModuleDecl) -> None:
         if not isinstance(decl, VarDecl):
             continue
         site = decl.site
-        if site.annotation is not None:
+        if site.annotation is not inspect._empty:
             continue
         obj = decl.obj
         if obj is None:

--- a/macrotype/modules/transformers/foreign_symbol.py
+++ b/macrotype/modules/transformers/foreign_symbol.py
@@ -21,11 +21,11 @@ def canonicalize_foreign_symbols(mi: ModuleDecl) -> None:
             new_syms.append(sym)
             continue
         if not hasattr(obj, "__module__"):
-            if sym.name in annotations or isinstance(obj, (int, str, float, bool)):
+            if sym.name in annotations or isinstance(obj, (int, str, float, bool)) or obj is None:
                 new_syms.append(sym)
             continue
         if obj.__module__ != modname:
-            if sym.name in annotations or isinstance(obj, (int, str, float, bool)):
+            if sym.name in annotations or isinstance(obj, (int, str, float, bool)) or obj is None:
                 new_syms.append(sym)
                 continue
             alias_name = getattr(obj, "__name__", None)

--- a/macrotype/modules/transformers/param_default.py
+++ b/macrotype/modules/transformers/param_default.py
@@ -25,7 +25,7 @@ def _infer_function(sym: FuncDecl, fn: Callable) -> None:
             if site.name != display:
                 site = Site(role="param", name=display, annotation=site.annotation)
         else:
-            ann = None
+            ann = inspect._empty
             if (
                 p.default is not inspect._empty
                 and p.default is not None

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -132,6 +132,8 @@ UNANNOTATED_CONST = 42
 UNANNOTATED_STR = "hi"
 # Edge case: unannotated float constant should be included
 UNANNOTATED_FLOAT = 1.23
+# Explicit None annotation should remain None
+EXPLICIT_NONE: None = None
 
 
 # Edge case: subclass constants should preserve subclass type
@@ -163,6 +165,11 @@ def mult(a, b=1):
 # Defaults of ``None`` do not refine "Any"
 def takes_optional(x=None):
     return x
+
+
+# Explicit None parameter annotation should emit None, not NoneType
+def takes_none_param(x: None) -> None:
+    pass
 
 
 # Duplicate local aliases should be canonicalized

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -109,6 +109,8 @@ UNANNOTATED_STR: str
 
 UNANNOTATED_FLOAT: float
 
+EXPLICIT_NONE: None
+
 class CustomInt(int): ...
 
 UNANNOTATED_CUSTOM_INT: CustomInt
@@ -124,6 +126,8 @@ COMMENTED_VAR: int  # pragma: var
 def mult(a, b: int): ...
 
 def takes_optional(x): ...
+
+def takes_none_param(x: None) -> None: ...
 
 def _alias_target() -> None: ...
 

--- a/tests/modules/transformers/test_transformers.py
+++ b/tests/modules/transformers/test_transformers.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import linecache
 import textwrap
 import typing as t
@@ -122,11 +123,25 @@ def test_constant_transform() -> None:
         pass
 
     members = [
-        VarDecl(name="ANSWER", site=Site(role="var", name="ANSWER"), obj=42),
-        VarDecl(name="GREETING", site=Site(role="var", name="GREETING"), obj="hi"),
-        VarDecl(name="RATE", site=Site(role="var", name="RATE"), obj=1.5),
-        VarDecl(name="FLAG", site=Site(role="var", name="FLAG"), obj=True),
-        VarDecl(name="CUSTOM", site=Site(role="var", name="CUSTOM"), obj=CustomInt(1)),
+        VarDecl(
+            name="ANSWER", site=Site(role="var", name="ANSWER", annotation=inspect._empty), obj=42
+        ),
+        VarDecl(
+            name="GREETING",
+            site=Site(role="var", name="GREETING", annotation=inspect._empty),
+            obj="hi",
+        ),
+        VarDecl(
+            name="RATE", site=Site(role="var", name="RATE", annotation=inspect._empty), obj=1.5
+        ),
+        VarDecl(
+            name="FLAG", site=Site(role="var", name="FLAG", annotation=inspect._empty), obj=True
+        ),
+        VarDecl(
+            name="CUSTOM",
+            site=Site(role="var", name="CUSTOM", annotation=inspect._empty),
+            obj=CustomInt(1),
+        ),
     ]
     mi = ModuleDecl(name="consts", obj=ModuleType("consts"), members=members)
     infer_constant_types(mi)
@@ -140,7 +155,7 @@ def test_constant_transform() -> None:
     assert greet.site.annotation is str
     assert rate.site.annotation is float
     assert flag.site.annotation is bool
-    assert custom.site.annotation is None
+    assert custom.site.annotation is inspect._empty
 
 
 def test_dataclass_transform() -> None:
@@ -514,7 +529,7 @@ def test_infer_param_defaults_transform() -> None:
     infer_param_defaults(mi)
     fn = next(s for s in mi.members if isinstance(s, FuncDecl) and s.name == "mult")
     assert [p.name for p in fn.params] == ["a", "b"]
-    assert fn.params[0].annotation is None
+    assert fn.params[0].annotation is inspect._empty
     assert fn.params[1].annotation in (int, "int")
 
 


### PR DESCRIPTION
## Summary
- distinguish explicit `None` annotations from unannotated parameters in module emission
- avoid dropping variables assigned to `None` in foreign symbol canonicalization
- add tests covering explicit `None` parameters and type inference

## Testing
- `pytest tests/test_all.py::test_stub_generation_matches_expected -q`
- `pytest tests/modules/transformers/test_transformers.py::test_constant_transform tests/modules/transformers/test_transformers.py::test_infer_param_defaults_transform -q`


------
https://chatgpt.com/codex/tasks/task_e_689f62d5f7dc832984c8508e7b6881b4