### PR TITLE
Handle ParamSpec args and kwargs

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -162,6 +162,18 @@ def stringify_annotation(ann: Any, name_map: dict[int, str]) -> str:
         params_str = ", ".join(stringify_annotation(p, name_map) for p in params)
         return f"{name}[[{params_str}], {ret_str}]"
 
+    if origin is t.Unpack:
+        (inner,) = args
+        if inner.__class__ is t.ParamSpecArgs:
+            ps = getattr(inner, "__origin__", None)
+            name = name_map.get(id(ps), getattr(ps, "__name__", repr(ps)))
+            return f"*{name}.args"
+        if inner.__class__ is t.ParamSpecKwargs:
+            ps = getattr(inner, "__origin__", None)
+            name = name_map.get(id(ps), getattr(ps, "__name__", repr(ps)))
+            return f"**{name}.kwargs"
+        return f"Unpack[{stringify_annotation(inner, name_map)}]"
+
     if origin is Annotated:
         first, *metas = args
         parts = [stringify_annotation(first, name_map)]

--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -130,6 +130,16 @@ def stringify_annotation(ann: Any, name_map: dict[int, str]) -> str:
     if isinstance(ann, str):
         return repr(ann)
 
+    if ann.__class__ is t.ParamSpecArgs:
+        origin = getattr(ann, "__origin__", None)
+        name = name_map.get(id(origin), getattr(origin, "__name__", repr(origin)))
+        return f"{name}.args"
+
+    if ann.__class__ is t.ParamSpecKwargs:
+        origin = getattr(ann, "__origin__", None)
+        name = name_map.get(id(origin), getattr(origin, "__name__", repr(origin)))
+        return f"{name}.kwargs"
+
     origin, args = _origin_and_args(ann)
 
     if origin is types.UnionType:

--- a/macrotype/types/ir.py
+++ b/macrotype/types/ir.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import enum
 from dataclasses import dataclass, field
 from types import EllipsisType
-from typing import NewType, Optional, TypeAlias
+from typing import Literal, NewType, Optional, TypeAlias
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -162,6 +162,7 @@ class TyParamSpec(Ty):
     """
 
     name: str
+    flavor: Literal["args", "kwargs"] | None = None
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/macrotype/types/parse.py
+++ b/macrotype/types/parse.py
@@ -127,6 +127,14 @@ def _to_ir(tp: object, env: ParseEnv) -> Ty:
             raise ValueError("Qualifiers like ClassVar/Final are only valid at the root")
         return _tytype_of(tp)
 
+    if tp.__class__ is t.ParamSpecArgs:
+        name = getattr(origin, "__name__", repr(origin))
+        return TyParamSpec(name=name, flavor="args")
+
+    if tp.__class__ is t.ParamSpecKwargs:
+        name = getattr(origin, "__name__", repr(origin))
+        return TyParamSpec(name=name, flavor="kwargs")
+
     if origin in (t.ClassVar, t.Final, t.Required, t.NotRequired):
         raise ValueError("Qualifiers like ClassVar/Final are only valid at the root")
 
@@ -220,7 +228,7 @@ def parse_root(tp: object, env: Optional[ParseEnv] = None) -> TyRoot:
             args = get_args(obj)
             obj = args[0] if args else _missing
             qualifiers.add(origin)
-        elif obj in valid_qualifiers:
+        elif any(obj is q for q in valid_qualifiers):
             qualifiers.add(obj)
             obj = _missing
         else:

--- a/macrotype/types/unparse.py
+++ b/macrotype/types/unparse.py
@@ -94,6 +94,10 @@ def _unparse_no_annos(n: Ty) -> Any:
             return t.Callable[params_list, _unparse(r)]
         case TyUnpack(inner=i):
             return t.Unpack[_unparse(i)]
+        case TyParamSpec(name=n, flavor="args"):
+            return t.ParamSpec(n).args
+        case TyParamSpec(name=n, flavor="kwargs"):
+            return t.ParamSpec(n).kwargs
         case TyParamSpec(name=n):
             return t.ParamSpec(n)
         case TyTypeVar(name=n, bound=b, constraints=cs, cov=cv, contrav=cn):

--- a/macrotype/types_ast.py
+++ b/macrotype/types_ast.py
@@ -1064,12 +1064,6 @@ def find_typevars(type_obj: Any) -> set[str]:
                 found.add(f"**{typ.__name__}")
             elif isinstance(typ, typing.TypeVarTuple):
                 found.add(f"*{typ.__name__}")
-        elif isinstance(node, AtomNode):
-            typ = node.type_
-            if isinstance(typ, typing.ParamSpecArgs):
-                found.add(f"**{typ.__origin__.__name__}")
-            elif isinstance(typ, typing.ParamSpecKwargs):
-                found.add(f"**{typ.__origin__.__name__}")
         elif isinstance(node, TypeNode):
             for alt in node.alts:
                 _collect(alt)
@@ -1090,10 +1084,6 @@ def find_typevars(type_obj: Any) -> set[str]:
             collected.add(t.__name__)
         elif isinstance(t, typing.ParamSpec):
             collected.add(f"**{t.__name__}")
-        elif isinstance(t, typing.ParamSpecArgs):
-            collected.add(f"**{t.__origin__.__name__}")
-        elif isinstance(t, typing.ParamSpecKwargs):
-            collected.add(f"**{t.__origin__.__name__}")
         elif isinstance(t, typing.TypeVarTuple):
             collected.add(f"*{t.__name__}")
         elif hasattr(t, "__parameters__"):

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -98,6 +98,11 @@ type IntFunc[**P] = Callable[P, int]
 type LabeledTuple[*Ts] = tuple[str, *Ts]
 type RecursiveList[T] = T | list[RecursiveList[T]]
 
+
+# Function using ParamSpecArgs and ParamSpecKwargs
+def with_paramspec_args_kwargs(fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
+
+
 GLOBAL: int
 CONST: Final[str]
 # Variable typed ``Any`` to ensure explicit Any is preserved

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -93,6 +93,8 @@ type LabeledTuple[*Ts] = tuple[str, Unpack[Ts]]
 
 type RecursiveList[T] = T | list[RecursiveList[T]]
 
+def with_paramspec_args_kwargs[**P](fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
+
 ANNOTATED_FINAL: Final[int]
 
 ANNOTATED_CLASSVAR: int

--- a/tests/types/test_parse.py
+++ b/tests/types/test_parse.py
@@ -198,6 +198,8 @@ CASES: list[tuple[object, TyRoot]] = [
         r(TyTypeVar(name="T", bound=None, constraints=(), cov=False, contrav=False)),
     ),
     (P, r(TyParamSpec(name="P"))),
+    (P.args, r(TyParamSpec(name="P", flavor="args"))),
+    (P.kwargs, r(TyParamSpec(name="P", flavor="kwargs"))),
     (Ts, r(TyTypeVarTuple(name="Ts"))),
     (t.Unpack[Ts], r(TyUnpack(inner=TyTypeVarTuple(name="Ts")))),
     # typing.Type / builtins.type

--- a/tests/types/test_parse.py
+++ b/tests/types/test_parse.py
@@ -200,6 +200,8 @@ CASES: list[tuple[object, TyRoot]] = [
     (P, r(TyParamSpec(name="P"))),
     (P.args, r(TyParamSpec(name="P", flavor="args"))),
     (P.kwargs, r(TyParamSpec(name="P", flavor="kwargs"))),
+    (t.Unpack[P.args], r(TyUnpack(inner=TyParamSpec(name="P", flavor="args")))),
+    (t.Unpack[P.kwargs], r(TyUnpack(inner=TyParamSpec(name="P", flavor="kwargs")))),
     (Ts, r(TyTypeVarTuple(name="Ts"))),
     (t.Unpack[Ts], r(TyUnpack(inner=TyTypeVarTuple(name="Ts")))),
     # typing.Type / builtins.type


### PR DESCRIPTION
## Summary
- support ParamSpecArgs and ParamSpecKwargs in module emission and type processing
- test ParamSpec args/kwargs through annotations and parsing

## Testing
- `ruff format macrotype tests`
- `ruff check --fix macrotype tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f74450334832999e40be60a19dc73