### PR TITLE
Handle enum value emission

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -106,16 +106,27 @@ def flatten_annotation_atoms(ann: Any) -> dict[int, Any]:
 
 def build_name_map(atoms: Iterable[Any], context: dict[str, Any]) -> dict[int, str]:
     """Map annotation atoms to names based on module context."""
-    reverse = {id(v): k for k, v in context.items()}
+    module_name = context.get("__name__")
+    reverse: dict[int, str] = {}
+    for k, v in context.items():
+        reverse.setdefault(id(v), k)
+
     name_map: dict[int, str] = {}
 
     for atom in atoms:
         atom_id = id(atom)
         if isinstance(atom, ForwardRef):
             name_map[atom_id] = atom.__forward_arg__
-        elif atom_id in reverse:
-            name_map[atom_id] = reverse[atom_id]
-        elif hasattr(atom, "__name__"):
+            continue
+        if atom_id in reverse:
+            name = reverse[atom_id]
+            mod = getattr(atom, "__module__", None)
+            if mod not in {module_name, "builtins"} and hasattr(atom, "__name__"):
+                name_map[atom_id] = atom.__name__
+            else:
+                name_map[atom_id] = name
+            continue
+        if hasattr(atom, "__name__"):
             name_map[atom_id] = atom.__name__
         else:
             name_map[atom_id] = repr(atom)
@@ -154,15 +165,20 @@ def stringify_annotation(ann: Any, name_map: dict[int, str]) -> str:
     if origin in {Callable, ABC_Callable}:
         if not args:
             return "Callable"
+        name = name_map.get(id(origin), getattr(origin, "__name__", "Callable"))
         if len(args) == 2:
             params, ret = args
-            params = params if params is not Ellipsis else [Ellipsis]
+            ret_str = stringify_annotation(ret, name_map)
+            if params is Ellipsis:
+                return f"{name}[..., {ret_str}]"
+            if isinstance(params, t.ParamSpec):
+                params_str = stringify_annotation(params, name_map)
+                return f"{name}[{params_str}, {ret_str}]"
+            if not isinstance(params, (list, tuple)):
+                params = [params]
         else:
             *params, ret = args
-        ret_str = stringify_annotation(ret, name_map)
-        name = name_map.get(id(origin), getattr(origin, "__name__", "Callable"))
-        if params == [Ellipsis]:
-            return f"{name}[..., {ret_str}]"
+            ret_str = stringify_annotation(ret, name_map)
         params_str = ", ".join(stringify_annotation(p, name_map) for p in params)
         return f"{name}[[{params_str}], {ret_str}]"
 
@@ -206,6 +222,8 @@ def stringify_value(val: Any, name_map: dict[int, str]) -> str:
         cls = val.__class__
         cls_name = name_map.get(id(cls), getattr(cls, "__name__", repr(cls)))
         return f"{cls_name}.{val.name}"
+    if isinstance(val, (int, float, bool)) or val is None:
+        return repr(val)
     if isinstance(val, str):
         return repr(val)
     return name_map.get(id(val), repr(val))

--- a/macrotype/modules/transformers/descriptor.py
+++ b/macrotype/modules/transformers/descriptor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 """Normalize method descriptors into function symbols."""
 
+import enum
 import functools
 import inspect
 from dataclasses import replace
@@ -9,6 +10,8 @@ from typing import Any
 
 from macrotype.modules.ir import ClassDecl, FuncDecl, ModuleDecl
 from macrotype.modules.scanner import _scan_function
+
+from .enum import _auto_enum_methods
 
 # Mapping of descriptor types to the attribute holding the underlying
 # function and the decorator string to attach.
@@ -99,7 +102,10 @@ def _descriptor_members(attr_name: str, attr: Any, cls: type) -> list[FuncDecl]:
 def _transform_class(sym: ClassDecl, cls: type) -> None:
     members = list(sym.members)
 
+    auto = _auto_enum_methods(cls) if isinstance(cls, enum.EnumMeta) else set()
     for attr_name, attr in cls.__dict__.items():
+        if attr_name in auto:
+            continue
         desc_members = _descriptor_members(attr_name, attr, cls)
         if desc_members:
             for i, m in enumerate(members):

--- a/macrotype/modules/transformers/foreign_symbol.py
+++ b/macrotype/modules/transformers/foreign_symbol.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from macrotype.modules.ir import Decl, ModuleDecl, Site, TypeDefDecl, VarDecl
+from macrotype.modules.ir import ClassDecl, Decl, FuncDecl, ModuleDecl, Site, TypeDefDecl, VarDecl
 
 
 def canonicalize_foreign_symbols(mi: ModuleDecl) -> None:
@@ -13,10 +13,15 @@ def canonicalize_foreign_symbols(mi: ModuleDecl) -> None:
     annotations: dict[str, t.Any] = glb.get("__annotations__", {}) or {}
     new_syms: list[Decl] = []
     for sym in mi.members:
+        obj = getattr(sym, "obj", None)
+        if isinstance(sym, (ClassDecl, FuncDecl)):
+            if hasattr(obj, "__module__") and obj.__module__ != modname:
+                continue
+            new_syms.append(sym)
+            continue
         if not isinstance(sym, VarDecl):
             new_syms.append(sym)
             continue
-        obj = sym.obj
         if obj is Ellipsis:
             new_syms.append(sym)
             continue

--- a/macrotype/modules/transformers/resolve_imports.py
+++ b/macrotype/modules/transformers/resolve_imports.py
@@ -30,7 +30,7 @@ def resolve_imports(mi: ModuleDecl) -> None:
     typing_names = {
         name_map[id(a)]
         for a in atoms.values()
-        if getattr(a, "__module__", None) == "typing" or a in {Callable, ABC_Callable}
+        if getattr(a, "__module__", None) == "typing" or a is Callable or a is ABC_Callable
     }
     typing_names.update(_collect_typing_names(mi.members))
 

--- a/macrotype/modules/transformers/resolve_imports.py
+++ b/macrotype/modules/transformers/resolve_imports.py
@@ -23,6 +23,12 @@ def resolve_imports(mi: ModuleDecl) -> None:
     atoms: dict[int, t.Any] = {}
     for ann in annotations:
         atoms.update(flatten_annotation_atoms(ann))
+    for sym in mi.get_all_decls():
+        for deco in getattr(sym, "decorators", ()):  # capture decorator objects
+            base = deco.split("(")[0].split(".")[-1]
+            obj = getattr(mi.obj, base, None)
+            if obj is not None:
+                atoms[id(obj)] = obj
 
     context = mi.obj.__dict__
     name_map = build_name_map(atoms.values(), context)
@@ -30,7 +36,14 @@ def resolve_imports(mi: ModuleDecl) -> None:
     typing_names = {
         name_map[id(a)]
         for a in atoms.values()
-        if getattr(a, "__module__", None) == "typing" or a is Callable or a is ABC_Callable
+        if (
+            (
+                getattr(a, "__module__", None) == "typing"
+                and not isinstance(a, (t.TypeVar, t.ParamSpec, t.TypeVarTuple))
+            )
+            or a is Callable
+            or a is ABC_Callable
+        )
     }
     typing_names.update(_collect_typing_names(mi.members))
 
@@ -44,6 +57,10 @@ def resolve_imports(mi: ModuleDecl) -> None:
             continue
         modname = _MODULE_ALIASES.get(modname, modname)
         if modname in {"builtins", "typing", mi.obj.__name__}:
+            continue
+        if modname == "enum" and name in {"Flag", "ReprEnum"}:
+            continue
+        if modname == "types" and name == "UnionType":
             continue
         external[modname].add(name)
 

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -521,6 +521,15 @@ class StrEnum(str, Enum):
     B = "b"
 
 
+ORIGIN = Point(x=0, y=0)
+
+
+# Enum with custom value types to ensure constructor and variable names are emitted
+class PointEnum(Enum):
+    INLINE = Point(x=1, y=2)
+    REF = ORIGIN
+
+
 class NamedPoint(NamedTuple):
     x: int
     y: int

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -347,6 +347,10 @@ class StrEnum(str, Enum):
     A = 'a'
     B = 'b'
 
+class PointEnum(Enum):
+    INLINE = Point(x=1, y=2)
+    REF = Point(x=0, y=0)
+
 class NamedPoint(NamedTuple):
     x: int
     y: int

--- a/tests/modules/test_emit_annotations.py
+++ b/tests/modules/test_emit_annotations.py
@@ -1,0 +1,33 @@
+from importlib import import_module
+
+from macrotype.modules import emit_module, from_module
+
+
+def test_emit_annotations_enums() -> None:
+    ann = import_module("tests.annotations")
+    mi = from_module(ann)
+    lines = emit_module(mi)
+
+    assert "from enum import Enum, IntEnum, IntFlag" in lines
+
+    idx = lines.index("class Color(Enum):")
+    assert lines[idx + 1] == "    RED = 1"
+    assert lines[idx + 2] == "    GREEN = 2"
+
+    idx = lines.index("class Priority(IntEnum):")
+    assert lines[idx + 1] == "    LOW = 1"
+    assert lines[idx + 2] == "    MEDIUM = 2"
+    assert lines[idx + 3] == "    HIGH = 3"
+
+    idx = lines.index("class Permission(IntFlag):")
+    assert lines[idx + 1] == "    READ = 1"
+    assert lines[idx + 2] == "    WRITE = 2"
+    assert lines[idx + 3] == "    EXECUTE = 4"
+
+    idx = lines.index("class StrEnum(str, Enum):")
+    assert lines[idx + 1] == "    A = 'a'"
+    assert lines[idx + 2] == "    B = 'b'"
+
+    idx = lines.index("class PointEnum(Enum):")
+    assert lines[idx + 1] == "    INLINE = Point(x=1, y=2)"
+    assert lines[idx + 2] == "    REF = ORIGIN"


### PR DESCRIPTION
## Summary
- emit enum member values and other assignments in `macrotype.modules.emit`, including strings and custom types
- avoid hashing unhashable atoms when resolving imports
- exercise enum emission with a custom value type in annotation fixtures

## Testing
- `ruff check --fix macrotype/modules/emit.py tests/annotations.py`
- `ruff check --fix macrotype/modules/transformers/resolve_imports.py`
- `python -m macrotype tests/annotations.py -o tests/annotations.pyi`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fad19e52083299635cc2d67cb8a70