### PR TITLE
Handle Annotated metadata in emit/unparse

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -88,6 +88,14 @@ def flatten_annotation_atoms(ann: Any) -> dict[int, Any]:
             atoms[obj_id] = obj
             continue
 
+        if origin is Annotated:
+            first, *metas = args
+            stack.append(first)
+            for meta in metas:
+                atoms[id(meta)] = meta
+            atoms[id(origin)] = origin
+            continue
+
         if origin is not None:
             atoms[id(origin)] = origin
             stack.extend(args)
@@ -178,10 +186,7 @@ def stringify_annotation(ann: Any, name_map: dict[int, str]) -> str:
         first, *metas = args
         parts = [stringify_annotation(first, name_map)]
         for meta in metas:
-            if isinstance(meta, str):
-                parts.append(repr(meta))
-            else:
-                parts.append(stringify_annotation(meta, name_map))
+            parts.append(name_map.get(id(meta), repr(meta)))
         return f"Annotated[{', '.join(parts)}]"
 
     if origin is tuple and args == ((),):

--- a/macrotype/types/unparse.py
+++ b/macrotype/types/unparse.py
@@ -49,8 +49,7 @@ def _apply_annos(inner: Any, tree) -> Any:
     node = tree
     out = inner
     while node:
-        args = (out, *node.annos)
-        out = t.Annotated[args]
+        out = t.Annotated[(out, *node.annos)]
         node = node.child
     return out
 

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -226,6 +226,16 @@ ANNOTATED_FINAL_META: Annotated[Final[int], "meta"] = 2
 # Outer Annotated around a generic with inner Annotated element
 ANNOTATED_WRAP_GENERIC: Annotated[list[Annotated[int, "inner"]], "outer"] = []
 
+
+# Annotated metadata using arbitrary object to verify pass-through
+class MetaRepr:
+    def __repr__(self) -> str:  # pragma: no cover - simple repr
+        return "MetaRepr()"
+
+
+META_REPR = MetaRepr()
+ANNOTATED_OBJ_META: Annotated[int, META_REPR] = 0
+
 # Built-in generic without dedicated handler
 GENERIC_DEQUE: Deque[int]
 # Deque with nested list to exercise TypeNode inside GenericNode

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype tests/annotations.py -o tests/annotations.pyi
+# Generated via: macrotype -o - tests/annotations.py
 # Do not edit by hand
 # pyright: basic
 from abc import ABC, abstractmethod
@@ -158,6 +158,11 @@ ANNOTATED_OPTIONAL_META: Annotated[None | int, 'meta']
 ANNOTATED_FINAL_META: Final[Annotated[int, 'meta']]
 
 ANNOTATED_WRAP_GENERIC: Annotated[list[Annotated[int, 'inner']], 'outer']
+
+class MetaRepr:
+    def __repr__(self) -> str: ...
+
+ANNOTATED_OBJ_META: Annotated[int, MetaRepr()]
 
 class UserBox[T]: ...
 

--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -272,7 +272,25 @@ case11 = (
     ["from dataclasses import InitVar", "", "iv: InitVar[list[int]]"],
 )
 
-CASES = [case1, case2, case3, case4, case5, case6, case7, case8, case9, case10, case11]
+
+mod12 = ModuleType("m12")
+MetaObj = type("MetaObj", (), {"__module__": mod12.__name__, "__repr__": lambda self: "MetaObj()"})
+meta_obj = MetaObj()
+case12 = (
+    ModuleDecl(
+        name=mod12.__name__,
+        obj=mod12,
+        members=[
+            VarDecl(
+                name="ann_obj",
+                site=Site(role="var", annotation=Annotated[int, meta_obj]),
+            ),
+        ],
+    ),
+    ["from typing import Annotated", "", "ann_obj: Annotated[int, MetaObj()]"],
+)
+
+CASES = [case1, case2, case3, case4, case5, case6, case7, case8, case9, case10, case11, case12]
 
 
 def test_emit_module_table() -> None:

--- a/tests/types/test_unparse.py
+++ b/tests/types/test_unparse.py
@@ -26,6 +26,13 @@ def b(n: str) -> TyType:
     return TyType(type_=getattr(builtins, n))
 
 
+class MetaObj:
+    def __repr__(self) -> str:  # pragma: no cover - simple repr
+        return "MetaObj()"
+
+
+META = MetaObj()
+
 CASES: list[tuple[TyRoot, str]] = [
     (TyRoot(ty=TyAny()), "typing.Any"),
     (TyRoot(ty=TyNever()), "typing.Never"),
@@ -74,6 +81,10 @@ CASES: list[tuple[TyRoot, str]] = [
             )
         ),
         "dataclasses.InitVar[list[int]]",
+    ),
+    (
+        TyRoot(ty=TyType(type_=int, annotations=TyAnnoTree(annos=(META,)))),
+        "typing.Annotated[int, MetaObj()]",
     ),
 ]
 


### PR DESCRIPTION
## Summary
- preserve Annotated metadata when scanning annotations and emitting stubs
- reconstruct Annotated nodes during unparse
- test Annotated metadata pass-through and reconstruction

## Testing
- `ruff check --fix macrotype/modules/emit.py macrotype/types/unparse.py tests/modules/test_emit.py tests/types/test_unparse.py tests/annotations.py`
- `python -m macrotype -o - tests/annotations.py > /tmp/annotations.pyi`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fb2844abc83298c2a9d2b911f15b3