### PR TITLE
Support GenericAlias in alias handling and emission

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -275,6 +275,8 @@ def _emit_decl(sym: Decl, name_map: dict[int, str], *, indent: int) -> list[str]
                 case t.NewType:
                     ty = stringify_annotation(site.annotation, name_map)
                     rhs = f'NewType("{sym.name}", {ty})'
+                case types.GenericAlias():
+                    rhs = stringify_annotation(site.annotation, name_map)
                 case _:
                     raise NotImplementedError(f"Unsupported alias type: {alias!r}")
             line = f"{pad}{keyword}{sym.name}{param_str} = {rhs}"

--- a/macrotype/modules/transformers/alias.py
+++ b/macrotype/modules/transformers/alias.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import types
 import typing as t
 
 from macrotype.modules.ir import ClassDecl, Decl, ModuleDecl, Site, TypeDefDecl, VarDecl
@@ -11,7 +12,7 @@ def _transform_alias_vars(decls: list[Decl]) -> list[Decl]:
     for sym in decls:
         match sym:
             case VarDecl(name=name, obj=obj, comment=comment, emit=emit, site=site):
-                if isinstance(obj, (t.TypeVar, t.ParamSpec, t.TypeVarTuple)):
+                if isinstance(obj, (t.TypeVar, t.ParamSpec, t.TypeVarTuple, types.GenericAlias)):
                     alias = TypeDefDecl(
                         name=name,
                         value=Site(role="alias_value", annotation=obj, comment=site.comment),
@@ -59,5 +60,5 @@ def synthesize_aliases(mi: ModuleDecl) -> None:
             sym.type_params = tuple(params)
         elif annotations.get(sym.name) is t.TypeAlias:
             sym.obj_type = t.TypeAlias
-        elif isinstance(obj, (t.TypeVar, t.ParamSpec, t.TypeVarTuple)):
+        elif isinstance(obj, (t.TypeVar, t.ParamSpec, t.TypeVarTuple, types.GenericAlias)):
             sym.obj_type = obj

--- a/macrotype/pyi_extract.py
+++ b/macrotype/pyi_extract.py
@@ -1170,7 +1170,18 @@ class _ModuleBuilder:
                 self._add(var)
             else:
                 alias_name = getattr(obj, "__name__", None)
-                if alias_name and alias_name != name:
+                if isinstance(obj, types.GenericAlias):
+                    fmt = self._format_annotation(obj, name)
+                    self._add(
+                        PyiAlias(
+                            name=name,
+                            value=fmt.text,
+                            used_types=fmt.used,
+                            line=self.line_map.get(name),
+                        )
+                    )
+                    self.used_types.update(fmt.used)
+                elif alias_name and alias_name != name:
                     self._add(
                         PyiAlias(
                             name=name,

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -80,6 +80,9 @@ MyList: TypeAlias = list[int]
 # Simple alias to builtin container
 Other = dict[str, int]
 
+# Alias using GenericAlias
+ListIntGA = list[int]
+
 # Edge case: alias referencing a forward-declared class
 ForwardAlias: TypeAlias = "FutureClass"
 

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -67,7 +67,9 @@ type AliasBoundU[U] = list[U]
 
 MyList = list[int]
 
-Other = dict
+Other = dict[str, int]
+
+ListIntGA = list[int]
 
 ForwardAlias = FutureClass
 

--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -337,6 +337,22 @@ case14 = (
     ["x: None"],
 )
 
+mod15 = ModuleType("m15")
+case15 = (
+    ModuleDecl(
+        name=mod15.__name__,
+        obj=mod15,
+        members=[
+            TypeDefDecl(
+                name="GA",
+                value=Site(role="alias_value", annotation=list[int]),
+                obj_type=list[int],
+            )
+        ],
+    ),
+    ["GA = list[int]"],
+)
+
 CASES = [
     case1,
     case2,
@@ -352,6 +368,7 @@ CASES = [
     case12,
     case13,
     case14,
+    case15,
 ]
 
 

--- a/tests/modules/transformers/test_transformers.py
+++ b/tests/modules/transformers/test_transformers.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import linecache
 import textwrap
+import types
 import typing as t
 from types import ModuleType
 
@@ -100,6 +101,18 @@ def test_typevar_alias_transform() -> None:
     assert isinstance(t_alias, TypeDefDecl)
     assert isinstance(p_alias, TypeDefDecl)
     assert isinstance(ts_alias, TypeDefDecl)
+
+
+def test_genericalias_transform() -> None:
+    code = """
+    Alias = list[int]
+    """
+    mod = mod_from_code(code, "ga")
+    mi = scan_module(mod)
+    synthesize_aliases(mi)
+    alias = t.cast(TypeDefDecl, {s.name: s for s in mi.members}["Alias"])
+    assert isinstance(alias.obj_type, types.GenericAlias)
+    assert alias.value.annotation == list[int]
 
 
 def test_newtype_transform() -> None:


### PR DESCRIPTION
## Summary
- recognize `types.GenericAlias` when transforming and emitting type aliases
- format GenericAlias values during stub extraction
- cover GenericAlias with new unit tests

## Testing
- `ruff format`
- `ruff check --fix`
- `pytest tests/modules/test_emit.py tests/modules/transformers/test_transformers.py tests/test_all.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689fc4d2b1e08329b7d723756d5a69b8