### PR TITLE
Fix Callable ParamSpec stringification and roundtrip tests

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -188,7 +188,7 @@ def stringify_annotation(ann: Any, name_map: dict[int, str]) -> str:
             ret_str = stringify_annotation(ret, name_map)
             if params is Ellipsis:
                 return f"{name}[..., {ret_str}]"
-            if isinstance(params, t.ParamSpec):
+            if isinstance(params, t.ParamSpec) or get_origin(params) is t.Concatenate:
                 params_str = stringify_annotation(params, name_map)
                 return f"{name}[{params_str}, {ret_str}]"
             if not isinstance(params, (list, tuple)):

--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -9,6 +9,7 @@ from typing import (
     Any,
     Callable,
     ClassVar,
+    Concatenate,
     Literal,
     NewType,
     ParamSpec,
@@ -229,6 +230,17 @@ case9 = (
         "    ...",
     ],
 )
+
+
+def test_callable_paramspec():
+    P = ParamSpec("P")
+    ann1 = Callable[P, int]
+    nm1 = build_name_map(flatten_annotation_atoms(ann1), locals())
+    assert stringify_annotation(ann1, nm1) == "Callable[P, int]"
+
+    ann2 = Callable[Concatenate[int, P], int]
+    nm2 = build_name_map(flatten_annotation_atoms(ann2), locals())
+    assert stringify_annotation(ann2, nm2) == "Callable[Concatenate[int, P], int]"
 
 
 def test_paramspec_unpacked_in_generic():

--- a/tests/types/test_roundtrip.py
+++ b/tests/types/test_roundtrip.py
@@ -1,3 +1,5 @@
+import typing as t
+
 import pytest
 
 from macrotype.types import from_type, unparse_top
@@ -9,3 +11,15 @@ from macrotype.types import from_type, unparse_top
 )
 def test_tuple_roundtrip(tp):
     assert unparse_top(from_type(tp)) == tp
+
+
+def test_callable_paramspec_roundtrip():
+    P = t.ParamSpec("P")
+    ann = t.Callable[P, int]
+    assert repr(unparse_top(from_type(ann))) == repr(ann)
+
+
+def test_callable_concatenate_roundtrip():
+    P = t.ParamSpec("P")
+    ann = t.Callable[t.Concatenate[int, P], int]
+    assert repr(unparse_top(from_type(ann))) == repr(ann)


### PR DESCRIPTION
## Summary
- handle ParamSpec and Concatenate in Callable stringification
- test Callable+ParamSpec roundtrips through macrotype.types
- cover emitter Callable ParamSpec cases in unit tests

## Testing
- `ruff check --fix macrotype/modules/emit.py tests/modules/test_emit.py tests/types/test_roundtrip.py`
- `pytest tests/modules/test_emit.py::test_callable_paramspec tests/modules/test_emit.py::test_paramspec_unpacked_in_generic tests/types/test_roundtrip.py::test_callable_paramspec_roundtrip tests/types/test_roundtrip.py::test_callable_concatenate_roundtrip -q`

------
https://chatgpt.com/codex/tasks/task_e_689fc54ce82c83298a0d06b54017a960