### PR TITLE
Validate TypeVarTuple requires Unpack in tuple types

### DIFF
--- a/macrotype/types/validate.py
+++ b/macrotype/types/validate.py
@@ -57,6 +57,10 @@ def _v(node: Ty, *, ctx: Context) -> None:
 
         # tuple[...] forms (fixed-length or variadic)
         case TyApp(base=TyType(type_=tuple), args=args):
+            if any(isinstance(a, TyTypeVarTuple) for a in args):
+                raise TypeValidationError(
+                    "TypeVarTuple in tuple[...] must be wrapped in Unpack[...]"
+                )
             # Ellipsis, if present, must be last; only one allowed
             ell_count = sum(1 for a in args if isinstance(a, TyType) and a.type_ is EllipsisType)
             if ell_count:

--- a/tests/types/test_validate.py
+++ b/tests/types/test_validate.py
@@ -81,6 +81,7 @@ BAD = [
     TyApp(base=b("tuple"), args=(b("Ellipsis"), b("int"))),  # tuple[..., int] invalid
     TyApp(base=b("tuple"), args=(b("int"), b("Ellipsis"), b("str"))),  # Ellipsis not last
     TyApp(base=b("tuple"), args=(b("int"), b("Ellipsis"), b("Ellipsis"))),  # multiple Ellipsis
+    TyApp(base=b("tuple"), args=(TyTypeVarTuple(name="Ts"),)),  # tuple[Ts] missing Unpack
     TyUnion(options=()),  # empty Union slipped through
     TyUnpack(inner=TyTypeVarTuple(name="Ts")),  # Unpack outside tuple/Concatenate
 ]


### PR DESCRIPTION
## Summary
- ensure tuple[...] rejects bare TypeVarTuple without Unpack
- cover validation case in tests

## Testing
- `python -m macrotype.stubgen macrotype -o __macrotype__`
- `ruff format macrotype/types/validate.py tests/types/test_validate.py`
- `ruff check macrotype/types/validate.py tests/types/test_validate.py --fix`
- `pytest tests/types/test_validate.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689fcf99b6d08329a53ca5b87820d0ea