### PR TITLE
Handle ParamSpec unpack in modules strict mode

### DIFF
--- a/macrotype/types/resolve.py
+++ b/macrotype/types/resolve.py
@@ -89,7 +89,7 @@ def _res(node: Ty, env: ResolveEnv) -> Ty:
             )
 
         case TyUnpack(inner=inner):
-            res = TyUnpack(_res(inner, env))
+            res = TyUnpack(inner=_res(inner, env))
 
         case _:
             res = node

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -104,10 +104,6 @@ type TupleUnpackFirst[*Ts] = tuple[*Ts, int]  # Unpack before trailing element
 type RecursiveList[T] = T | list[RecursiveList[T]]
 
 
-# Function using ParamSpecArgs and ParamSpecKwargs
-def with_paramspec_args_kwargs(fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
-
-
 GLOBAL: int
 CONST: Final[str]
 # Variable typed ``Any`` to ensure explicit Any is preserved

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -98,8 +98,6 @@ type TupleUnpackFirst[*Ts] = tuple[Unpack[Ts], int]
 
 type RecursiveList[T] = T | list[RecursiveList[T]]
 
-def with_paramspec_args_kwargs[**P](fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
-
 ANNOTATED_FINAL: Final[int]
 
 ANNOTATED_CLASSVAR: int

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -1,0 +1,7 @@
+from typing import Callable, ParamSpec
+
+# Function using ParamSpecArgs and ParamSpecKwargs
+P = ParamSpec("P")
+
+
+def with_paramspec_args_kwargs(fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -1,0 +1,9 @@
+# Generated via: macrotype tests/annotations_new.py -o tests/annotations_new.pyi
+# Do not edit by hand
+from typing import Callable, ParamSpec
+
+P = ParamSpec("P")
+
+def with_paramspec_args_kwargs[**P](
+    fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs
+) -> int: ...

--- a/tests/modules/test_emit_annotations_new.py
+++ b/tests/modules/test_emit_annotations_new.py
@@ -1,0 +1,13 @@
+from importlib import import_module
+
+from macrotype.modules import emit_module, from_module
+
+
+def test_emit_annotations_new_strict() -> None:
+    ann = import_module("tests.annotations_new")
+    mi = from_module(ann, strict=True)
+    lines = emit_module(mi)
+    assert (
+        "def with_paramspec_args_kwargs[**P](fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ..."
+        in lines
+    )


### PR DESCRIPTION
## Summary
- support Unpack nodes during type resolution
- move ParamSpec args/kwargs example to `annotations_new.py`
- add strict modules test for ParamSpec unpacks

## Testing
- `ruff format tests/ macrotype/`
- `ruff check tests/ macrotype/ --fix`
- `pytest tests/modules/test_emit_annotations_new.py`


------
https://chatgpt.com/codex/tasks/task_e_689fd505de788329acf5398484d1d81e