### PR TITLE
Move prepend_one test to annotations_new

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -17,7 +17,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Concatenate,
     Deque,
     Final,
     Generic,
@@ -886,14 +885,6 @@ class Variadic(Generic[*Ts]):
 
     def to_tuple(self) -> tuple[Unpack[Ts]]:
         return self.args
-
-
-# Wrapper function using ``Concatenate`` with a ``ParamSpec`` parameter
-def prepend_one(fn: Callable[Concatenate[int, P], int]) -> Callable[P, int]:
-    def inner(*args: P.args, **kwargs: P.kwargs) -> int:
-        return fn(1, *args, **kwargs)
-
-    return inner
 
 
 # Demonstrate overload_for decorator generating literal overloads

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -16,7 +16,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Concatenate,
     Final,
     Literal,
     LiteralString,
@@ -507,8 +506,6 @@ def as_tuple[*Ts](*args: Unpack[Ts]) -> tuple[Unpack[Ts]]: ...
 class Variadic[*Ts]:
     def __init__(self, *args: Unpack[Ts]) -> None: ...
     def to_tuple(self) -> tuple[Unpack[Ts]]: ...
-
-def prepend_one[**P](fn: Callable[Concatenate[int, P], int]) -> Callable[P, int]: ...
 
 @overload
 def special_neg(val: Literal[0]) -> Literal[0]: ...

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -1,7 +1,15 @@
-from typing import Callable, ParamSpec
+from typing import Callable, Concatenate, ParamSpec
 
 # Function using ParamSpecArgs and ParamSpecKwargs
 P = ParamSpec("P")
 
 
 def with_paramspec_args_kwargs(fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
+
+
+# Wrapper function using ``Concatenate`` with a ``ParamSpec`` parameter
+def prepend_one(fn: Callable[Concatenate[int, P], int]) -> Callable[P, int]:
+    def inner(*args: P.args, **kwargs: P.kwargs) -> int:
+        return fn(1, *args, **kwargs)
+
+    return inner

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -1,9 +1,9 @@
 # Generated via: macrotype tests/annotations_new.py -o tests/annotations_new.pyi
 # Do not edit by hand
-from typing import Callable, ParamSpec
+from typing import Callable, Concatenate, ParamSpec
 
 P = ParamSpec("P")
 
-def with_paramspec_args_kwargs[**P](
-    fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs
-) -> int: ...
+def with_paramspec_args_kwargs[**P](fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
+
+def prepend_one[**P](fn: Callable[Concatenate[int, P], int]) -> Callable[P, int]: ...

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -4,6 +4,7 @@ from typing import Callable, Concatenate, ParamSpec
 
 P = ParamSpec("P")
 
-def with_paramspec_args_kwargs[**P](fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
-
+def with_paramspec_args_kwargs[**P](
+    fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs
+) -> int: ...
 def prepend_one[**P](fn: Callable[Concatenate[int, P], int]) -> Callable[P, int]: ...

--- a/tests/modules/test_emit_annotations_new.py
+++ b/tests/modules/test_emit_annotations_new.py
@@ -11,3 +11,7 @@ def test_emit_annotations_new_strict() -> None:
         "def with_paramspec_args_kwargs[**P](fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ..."
         in lines
     )
+    assert (
+        "def prepend_one[**P](fn: Callable[Concatenate[int, P], int]) -> Callable[P, int]: ..."
+        in lines
+    )


### PR DESCRIPTION
## Summary
- move `prepend_one` Concatenate ParamSpec example from `annotations.py` to `annotations_new.py`
- regenerate stubs and expand module strict test for the new function

## Testing
- `ruff check tests/annotations.pyi`
- `ruff check --fix tests/annotations.py tests/annotations_new.py tests/modules/test_emit_annotations_new.py tests/annotations_new.pyi`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689fd7318dfc83298c4e9085847c0058