### PR TITLE
Shift basic variable tests to new modules pipeline and handle empty tuple types

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -227,7 +227,7 @@ def stringify_annotation(ann: Any, name_map: dict[int, str]) -> str:
             parts.append(name_map.get(id(meta), _qualname(meta)))
         return f"Annotated[{', '.join(parts)}]"
 
-    if origin is tuple and args == ((),):
+    if origin is tuple and ann is not tuple and not args:
         name = name_map.get(id(origin), _qualname(origin))
         return f"{name}[()]"
 

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -103,23 +103,6 @@ type TupleUnpackFirst[*Ts] = tuple[*Ts, int]  # Unpack before trailing element
 type RecursiveList[T] = T | list[RecursiveList[T]]
 
 
-GLOBAL: int
-CONST: Final[str]
-# Variable typed ``Any`` to ensure explicit Any is preserved
-ANY_VAR: Any
-# Variable using ``Callable`` with ellipsis argument list
-FUNC_ELLIPSIS: Callable[..., int]
-# Unannotated tuple type
-TUPLE_UNANN: tuple
-# Empty tuple type
-TUPLE_EMPTY: tuple[()]
-# Single-element tuple type
-TUPLE_ONE: tuple[int]
-# Variable using tuple ellipsis syntax
-TUPLE_VAR: tuple[int, ...]
-# Variable using set and frozenset types to test container formatting
-SET_VAR: set[int]
-FROZENSET_VAR: frozenset[str]
 # Set containing a nested list to exercise TypeNode in set elements
 SET_LIST_VAR: set[list[str]]
 # Tuple containing a nested list to exercise TypeNode in tuple items

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -626,26 +626,6 @@ class RequiredUndefinedCls:
 
 def wrapped_callable(x: int, y: str) -> str: ...
 
-GLOBAL: int
-
-CONST: Final[str]
-
-ANY_VAR: Any
-
-FUNC_ELLIPSIS: Callable[..., int]
-
-TUPLE_UNANN: tuple
-
-TUPLE_EMPTY: tuple[()]
-
-TUPLE_ONE: tuple[int]
-
-TUPLE_VAR: tuple[int, ...]
-
-SET_VAR: set[int]
-
-FROZENSET_VAR: frozenset[str]
-
 SET_LIST_VAR: set[list[str]]
 
 TUPLE_LIST_VAR: tuple[list[str], int]

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -1,4 +1,4 @@
-from typing import Callable, Concatenate, ParamSpec
+from typing import Any, Callable, Concatenate, Final, ParamSpec
 
 from macrotype.meta_types import overload_for
 
@@ -34,3 +34,23 @@ def parse_int_or_none(val: str | None) -> int | None:
     if val is None:
         return None
     return int(val)
+
+
+# Basic variable annotations
+GLOBAL: int
+CONST: Final[str]
+# Variable typed ``Any`` to ensure explicit Any is preserved
+ANY_VAR: Any
+# Variable using ``Callable`` with ellipsis argument list
+FUNC_ELLIPSIS: Callable[..., int]
+# Unannotated tuple type
+TUPLE_UNANN: tuple
+# Empty tuple type
+TUPLE_EMPTY: tuple[()]
+# Single-element tuple type
+TUPLE_ONE: tuple[int]
+# Variable using tuple ellipsis syntax
+TUPLE_VAR: tuple[int, ...]
+# Variable using set and frozenset types to test container formatting
+SET_VAR: set[int]
+FROZENSET_VAR: frozenset[str]

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -1,10 +1,9 @@
 # Generated via: macrotype tests/annotations_new.py --modules -o tests/annotations_new.pyi
 # Do not edit by hand
-from typing import Callable, Concatenate, Literal, ParamSpec, overload
+from typing import Any, Callable, Concatenate, Final, Literal, ParamSpec, overload
 
 P = ParamSpec("P")
 
-# fmt: off
 def with_paramspec_args_kwargs[**P](fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
 
 def prepend_one[**P](fn: Callable[Concatenate[int, P], int]) -> Callable[P, int]: ...
@@ -23,3 +22,23 @@ def parse_int_or_none(val: None) -> None: ...
 
 @overload
 def parse_int_or_none(val: None | str) -> None | int: ...
+
+GLOBAL: int
+
+CONST: Final[str]
+
+ANY_VAR: Any
+
+FUNC_ELLIPSIS: Callable[..., int]
+
+TUPLE_UNANN: tuple
+
+TUPLE_EMPTY: tuple[()]
+
+TUPLE_ONE: tuple[int]
+
+TUPLE_VAR: tuple[int, ...]
+
+SET_VAR: set[int]
+
+FROZENSET_VAR: frozenset[str]

--- a/tests/modules/test_ir.py
+++ b/tests/modules/test_ir.py
@@ -24,6 +24,7 @@ def idx() -> dict[str, object]:
     ann = importlib.import_module("tests.annotations")
     ann_new = importlib.import_module("tests.annotations_new")
     ann.special_neg = ann_new.special_neg
+    ann.__annotations__ |= ann_new.__annotations__
     mi = scan_module(ann)
     assert isinstance(mi, ModuleDecl)
     assert mi.obj is ann


### PR DESCRIPTION
## Summary
- Move initial variable annotations from annotations.py to annotations_new.py
- Fix modules emitter to output `tuple[()]` for empty tuple annotations
- Adjust IR tests to merge annotations from both modules

## Testing
- `ruff format tests/annotations_new.py tests/annotations.py macrotype/modules/emit.py`
- `ruff check --fix tests/annotations_new.py tests/annotations.py macrotype/modules/emit.py`
- `ruff check --fix tests/modules/test_ir.py`
- `pytest tests/modules/test_ir.py::test_module_var_and_func -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689fe5afc5908329b30ed103ce36fa86