### PR TITLE
Move alias tests to annotations_new and fix modules pipeline

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -183,8 +183,10 @@ def stringify_annotation(ann: Any, name_map: dict[int, str]) -> str:
 
     origin, args = _origin_and_args(ann)
 
-    if origin is types.UnionType:
-        return " | ".join(stringify_annotation(arg, name_map) for arg in args)
+    if origin in {types.UnionType, t.Union}:
+        items = [(arg, stringify_annotation(arg, name_map)) for arg in args]
+        items.sort(key=lambda item: (0 if isinstance(item[0], t.TypeVar) else 1))
+        return " | ".join(s for _, s in items)
 
     from collections.abc import Callable as ABC_Callable
 

--- a/macrotype/modules/transformers/alias.py
+++ b/macrotype/modules/transformers/alias.py
@@ -48,13 +48,10 @@ def synthesize_aliases(mi: ModuleDecl) -> None:
             sym.obj_type = obj
             params: list[str] = []
             for tp in getattr(obj, "__type_params__", ()):  # pragma: no cover - py312+
-                if glb.get(tp.__name__) is tp:
-                    if isinstance(tp, t.ParamSpec):
-                        params.append(f"**{tp.__name__}")
-                    elif isinstance(tp, t.TypeVarTuple):
-                        params.append(f"*{tp.__name__}")
-                    else:
-                        params.append(tp.__name__)
+                if isinstance(tp, t.ParamSpec):
+                    params.append(f"**{tp.__name__}")
+                elif isinstance(tp, t.TypeVarTuple):
+                    params.append(f"*{tp.__name__}")
                 else:
                     params.append(tp.__name__)
             sym.type_params = tuple(params)

--- a/macrotype/modules/transformers/resolve_imports.py
+++ b/macrotype/modules/transformers/resolve_imports.py
@@ -40,6 +40,7 @@ def resolve_imports(mi: ModuleDecl) -> None:
             (
                 getattr(a, "__module__", None) == "typing"
                 and not isinstance(a, (t.TypeVar, t.ParamSpec, t.TypeVarTuple))
+                and a is not t.Union
             )
             or a is Callable
             or a is ABC_Callable

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -32,8 +32,6 @@ from typing import (
     Protocol,
     Required,
     Self,
-    TypeAlias,
-    TypeAliasType,
     TypedDict,
     TypeGuard,
     TypeVar,
@@ -66,42 +64,6 @@ CovariantT = TypeVar("CovariantT", covariant=True)
 ContravariantT = TypeVar("ContravariantT", contravariant=True)
 TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
-
-# Type aliases created via ``TypeAliasType``
-AliasListT = TypeAliasType("AliasListT", list[T], type_params=(T,))
-AliasTupleTs = TypeAliasType("AliasTupleTs", tuple[Unpack[Ts]], type_params=(Ts,))
-AliasNumberLikeList = TypeAliasType(
-    "AliasNumberLikeList", list[NumberLike], type_params=(NumberLike,)
-)
-AliasBoundU = TypeAliasType("AliasBoundU", list[U], type_params=(U,))
-
-MyList: TypeAlias = list[int]
-
-# Simple alias to builtin container
-Other = dict[str, int]
-
-# Alias using GenericAlias
-ListIntGA = list[int]
-
-# Edge case: alias referencing a forward-declared class
-ForwardAlias: TypeAlias = "FutureClass"
-
-# Type alias for callable using ParamSpec
-CallableP: TypeAlias = Callable[P, int]
-
-# PEP 695 ``type`` statements
-type StrList = list[str]
-type Alias0[T] = list[T]
-type Alias1[T] = Alias0[T]
-type AliasNewType = UserId
-type AliasTypeVar[T] = T
-type AliasUnion = int | str
-type ListOrSet[T] = list[T] | set[T]
-type IntFunc[**P] = Callable[P, int]
-type LabeledTuple[*Ts] = tuple[str, *Ts]
-type TupleUnpackFirst[*Ts] = tuple[*Ts, int]  # Unpack before trailing element
-type RecursiveList[T] = T | list[RecursiveList[T]]
-
 
 # Set containing a nested list to exercise TypeNode in set elements
 SET_LIST_VAR: set[list[str]]
@@ -201,7 +163,7 @@ def commented_func(x: int) -> None:  # pragma: func
 
 
 # Edge case: lambda expressions should be treated as variables, not functions
-UNTYPED_LAMBDA = lambda x, y: x + y
+UNTYPED_LAMBDA = lambda x, y: x + y  # noqa: F821
 TYPED_LAMBDA: Callable[[int, int], int] = lambda a, b: a + b
 
 # Additional variable using ``Annotated`` to test type parsing

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -57,46 +57,6 @@ TDV = TypeVar("TDV")
 
 UserId = NewType("UserId", int)
 
-type AliasListT[T] = list[T]
-
-type AliasTupleTs[*Ts] = tuple[Unpack[Ts]]
-
-type AliasNumberLikeList[NumberLike] = list[NumberLike]
-
-type AliasBoundU[U] = list[U]
-
-MyList = list[int]
-
-Other = dict[str, int]
-
-ListIntGA = list[int]
-
-ForwardAlias = FutureClass
-
-CallableP = Callable[P, int]
-
-type StrList = list[str]
-
-type Alias0[T] = list[T]
-
-type Alias1[T] = Alias0[T]
-
-type AliasNewType = UserId
-
-type AliasTypeVar[T] = T
-
-type AliasUnion = int | str
-
-type ListOrSet[T] = list[T] | set[T]
-
-type IntFunc[**P] = Callable[P, int]
-
-type LabeledTuple[*Ts] = tuple[str, Unpack[Ts]]
-
-type TupleUnpackFirst[*Ts] = tuple[Unpack[Ts], int]
-
-type RecursiveList[T] = T | list[RecursiveList[T]]
-
 ANNOTATED_FINAL: Final[int]
 
 ANNOTATED_CLASSVAR: int
@@ -147,7 +107,7 @@ def wrapped_with_default(x: int, y: int) -> int: ...
 
 def commented_func(x: int) -> None: ...  # pragma: func
 
-UNTYPED_LAMBDA: function
+UNTYPED_LAMBDA: function  # noqa: F821
 
 TYPED_LAMBDA: Callable[[int, int], int]
 

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -1,9 +1,29 @@
-from typing import Any, Callable, Concatenate, Final, ParamSpec
+from typing import (
+    Any,
+    Callable,
+    Concatenate,
+    Final,
+    NewType,
+    ParamSpec,
+    TypeAlias,
+    TypeAliasType,
+    TypeVar,
+    TypeVarTuple,
+    Unpack,
+)
 
 from macrotype.meta_types import overload_for
 
-# Function using ParamSpecArgs and ParamSpecKwargs
 P = ParamSpec("P")
+
+T = TypeVar("T")
+Ts = TypeVarTuple("Ts")
+U = TypeVar("U", bound=str)
+NumberLike = TypeVar("NumberLike", int, float)
+CovariantT = TypeVar("CovariantT", covariant=True)
+ContravariantT = TypeVar("ContravariantT", contravariant=True)
+TDV = TypeVar("TDV")
+UserId = NewType("UserId", int)
 
 
 def with_paramspec_args_kwargs(fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
@@ -36,6 +56,42 @@ def parse_int_or_none(val: str | None) -> int | None:
     return int(val)
 
 
+# Type aliases created via ``TypeAliasType``
+AliasListT = TypeAliasType("AliasListT", list[T], type_params=(T,))
+AliasTupleTs = TypeAliasType("AliasTupleTs", tuple[Unpack[Ts]], type_params=(Ts,))
+AliasNumberLikeList = TypeAliasType(
+    "AliasNumberLikeList", list[NumberLike], type_params=(NumberLike,)
+)
+AliasBoundU = TypeAliasType("AliasBoundU", list[U], type_params=(U,))
+
+MyList: TypeAlias = list[int]
+
+# Simple alias to builtin container
+Other = dict[str, int]
+
+# Alias using GenericAlias
+ListIntGA = list[int]
+
+# Edge case: alias referencing a forward-declared class
+ForwardAlias: TypeAlias = "FutureClass"  # noqa: F821
+
+# Type alias for callable using ParamSpec
+CallableP: TypeAlias = Callable[P, int]
+
+# PEP 695 ``type`` statements
+type StrList = list[str]
+type Alias0[T] = list[T]
+type Alias1[T] = Alias0[T]
+type AliasNewType = UserId
+type AliasTypeVar[T] = T
+type AliasUnion = int | str
+type ListOrSet[T] = list[T] | set[T]
+type IntFunc[**P] = Callable[P, int]
+type LabeledTuple[*Ts] = tuple[str, *Ts]
+type TupleUnpackFirst[*Ts] = tuple[*Ts, int]  # Unpack before trailing element
+type RecursiveList[T] = T | list[RecursiveList[T]]
+
+
 # Basic variable annotations
 GLOBAL: int
 CONST: Final[str]
@@ -54,3 +110,6 @@ TUPLE_VAR: tuple[int, ...]
 # Variable using set and frozenset types to test container formatting
 SET_VAR: set[int]
 FROZENSET_VAR: frozenset[str]
+
+
+class FutureClass: ...

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -1,8 +1,25 @@
 # Generated via: macrotype tests/annotations_new.py --modules -o tests/annotations_new.pyi
 # Do not edit by hand
-from typing import Any, Callable, Concatenate, Final, Literal, ParamSpec, overload
+# fmt: off
+from typing import Any, Callable, Concatenate, Final, Literal, NewType, ParamSpec, TypeVar, TypeVarTuple, Unpack, overload
 
 P = ParamSpec("P")
+
+T = TypeVar("T")
+
+Ts = TypeVarTuple("Ts")
+
+U = TypeVar("U", bound=str)
+
+NumberLike = TypeVar("NumberLike", int, float)
+
+CovariantT = TypeVar("CovariantT", covariant=True)
+
+ContravariantT = TypeVar("ContravariantT", contravariant=True)
+
+TDV = TypeVar("TDV")
+
+UserId = NewType("UserId", int)
 
 def with_paramspec_args_kwargs[**P](fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
 
@@ -22,6 +39,49 @@ def parse_int_or_none(val: None) -> None: ...
 
 @overload
 def parse_int_or_none(val: None | str) -> None | int: ...
+
+type AliasListT[T] = list[T]
+
+type AliasTupleTs[*Ts] = tuple[Unpack[Ts]]
+
+type AliasNumberLikeList[NumberLike] = list[NumberLike]
+
+type AliasBoundU[U] = list[U]
+
+MyList = list[int]
+
+Other = dict[str, int]
+
+ListIntGA = list[int]
+
+ForwardAlias = FutureClass  # noqa: F821
+
+CallableP = Callable[P, int]
+
+type StrList = list[str]
+
+type Alias0[T] = list[T]
+
+type Alias1[T] = Alias0[T]
+
+type AliasNewType = UserId
+
+type AliasTypeVar[T] = T
+
+type AliasUnion = int | str
+
+type ListOrSet[T] = list[T] | set[T]
+
+type IntFunc[**P] = Callable[P, int]
+
+type LabeledTuple[*Ts] = tuple[str, Unpack[Ts]]
+
+type TupleUnpackFirst[*Ts] = tuple[Unpack[Ts], int]  # Unpack before trailing element
+
+type RecursiveList[T] = T | list[RecursiveList[T]]
+
+class FutureClass:
+    ...
 
 GLOBAL: int
 

--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -130,7 +130,7 @@ case4 = (
         ],
     ),
     [
-        "from typing import Callable, Union",
+        "from typing import Callable",
         "",
         "cb1: Callable[[int, str], bool]",
         "",
@@ -138,7 +138,7 @@ case4 = (
         "",
         "nested: list[Callable[[int], str]]",
         "",
-        "combo: Union[Callable[[int], str], Callable[..., bool]]",
+        "combo: Callable[[int], str] | Callable[..., bool]",
     ],
 )
 
@@ -190,9 +190,7 @@ case7 = (
         ],
     ),
     [
-        "from typing import Union",
-        "",
-        "u: Union[int, str]",
+        "u: int | str",
         "",
         "s: 'A'",
     ],

--- a/tests/modules/test_ir.py
+++ b/tests/modules/test_ir.py
@@ -66,7 +66,7 @@ def test_typeddict_fields(idx: dict[str, object]) -> None:
 
 
 def test_aliases() -> None:
-    ann = importlib.import_module("tests.annotations")
+    ann = importlib.import_module("tests.annotations_new")
     mi = scan_module(ann)
     canonicalize_foreign_symbols(mi)
     by_key = {s.name: s for s in mi.members}


### PR DESCRIPTION
## Summary
- move type alias and PEP 695 tests into `annotations_new`
- handle ParamSpec/TypeVarTuple type params and union pipes in modules emit
- skip unnecessary `Union` imports and update module tests

## Testing
- `pytest tests/test_all.py::test_cli_stdout[annotations_new.py-annotations_new.pyi-True] tests/test_all.py::test_stub_generation_matches_expected[annotations_new.py-annotations_new.pyi-True] tests/test_all.py::test_process_file[annotations_new.py-annotations_new.pyi-True] tests/test_all.py::test_process_directory[annotations_new.py-annotations_new.pyi-True] -q`
- `ruff check --fix tests/annotations.py tests/annotations_new.py macrotype/modules/transformers/alias.py macrotype/modules/emit.py macrotype/modules/transformers/resolve_imports.py tests/modules/test_emit.py tests/modules/test_ir.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ff64043ec8329a0645630f9639419