### PR TITLE
Handle bare Final constants in modules pipeline

### DIFF
--- a/macrotype/modules/__init__.py
+++ b/macrotype/modules/__init__.py
@@ -81,6 +81,7 @@ def from_module(mod: ModuleType, *, strict: bool = False) -> ModuleDecl:
     _t.transform_namedtuples(mi)
     _t.transform_generics(mi)
     _t.transform_dataclasses(mi)
+    _t.infer_constant_types(mi)
     _t.prune_inherited_typeddict_fields(mi)
     _t.infer_param_defaults(mi)
     _t.normalize_descriptors(mi)

--- a/macrotype/modules/transformers/constant.py
+++ b/macrotype/modules/transformers/constant.py
@@ -1,21 +1,25 @@
 from __future__ import annotations
 
 import inspect
+import typing as t
 
 from macrotype.modules.ir import ModuleDecl, VarDecl
 
 
 def infer_constant_types(mi: ModuleDecl) -> None:
-    """Populate missing annotations for simple constant assignments."""
+    """Populate annotations for simple constant assignments."""
     for decl in mi.get_all_decls():
         if not isinstance(decl, VarDecl):
             continue
         site = decl.site
-        if site.annotation is not inspect._empty:
-            continue
+        ann = site.annotation
         obj = decl.obj
         if obj is None:
             continue
         ty = type(obj)
-        if ty in {bool, int, float, str}:
-            site.annotation = ty
+        if ann is inspect._empty:
+            if ty in {bool, int, float, str}:
+                site.annotation = ty
+            continue
+        if ann is t.Final and ty in {bool, int, float, str}:
+            site.annotation = t.Final[ty]

--- a/macrotype/types/normalize.py
+++ b/macrotype/types/normalize.py
@@ -49,7 +49,7 @@ def norm(t: ResolvedTy | Ty, opts: NormOpts | None = None) -> NormalizedTy:
     """Normalize *t* according to *opts*."""
 
     top = t if isinstance(t, TyRoot) else TyRoot(ty=t)
-    inner = _norm(top.ty, opts or _DEFAULT)
+    inner = _norm(top.ty, opts or _DEFAULT) if top.ty is not None else None
     return NormalizedTy(
         TyRoot(
             ty=inner,
@@ -60,7 +60,9 @@ def norm(t: ResolvedTy | Ty, opts: NormOpts | None = None) -> NormalizedTy:
     )
 
 
-def _norm(n: Ty, o: NormOpts) -> Ty:
+def _norm(n: Ty | None, o: NormOpts) -> Ty | None:
+    if n is None:
+        return None
     ann = n.annotations
     if ann and o.drop_annotated_any and isinstance(n, TyAny):
         return TyAny()

--- a/macrotype/types/resolve.py
+++ b/macrotype/types/resolve.py
@@ -45,7 +45,7 @@ class ResolveEnv:
 def resolve(t: ParsedTy | Ty, env: ResolveEnv) -> ResolvedTy:
     """Resolve forward refs and qualify bare names. Pure; returns a new tree."""
     top = t if isinstance(t, TyRoot) else TyRoot(ty=t)
-    inner = _res(top.ty, env)
+    inner = _res(top.ty, env) if top.ty is not None else None
     return ResolvedTy(
         TyRoot(
             ty=inner,
@@ -56,7 +56,9 @@ def resolve(t: ParsedTy | Ty, env: ResolveEnv) -> ResolvedTy:
     )
 
 
-def _res(node: Ty, env: ResolveEnv) -> Ty:
+def _res(node: Ty | None, env: ResolveEnv) -> Ty | None:
+    if node is None:
+        return None
     ann = node.annotations
     match node:
         case TyAny() | TyNever() | TyParamSpec() | TyTypeVar() | TyTypeVarTuple() | TyType():

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -65,23 +65,6 @@ ContravariantT = TypeVar("ContravariantT", contravariant=True)
 TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
 
-# Set containing a nested list to exercise TypeNode in set elements
-SET_LIST_VAR: set[list[str]]
-# Tuple containing a nested list to exercise TypeNode in tuple items
-TUPLE_LIST_VAR: tuple[list[str], int]
-# List containing a callable to exercise TypeNode in callable parts
-CALLABLE_LIST_VAR: list[Callable[[int], str]]
-# Edge case: annotated constants with values should honor the annotation
-ANNOTATED_FINAL: Final[int] = 5
-ANNOTATED_CLASSVAR: int = 1
-
-# Literal string should retain quotes
-LITERAL_STR_VAR: Literal["hi"] = "hi"
-
-# ``Final`` without explicit type should infer from value
-BOX_SIZE: Final = 20
-BORDER_SIZE: Final = 4
-
 # Edge case: unannotated constant should be included
 UNANNOTATED_CONST = 42
 # Edge case: unannotated string constant should be included

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -28,10 +28,10 @@ from typing import (
     Protocol,
     Required,
     Self,
+    TypedDict,
     TypeGuard,
     TypeVar,
     TypeVarTuple,
-    TypedDict,
     Unpack,
     final,
     overload,
@@ -57,16 +57,6 @@ TDV = TypeVar("TDV")
 
 UserId = NewType("UserId", int)
 
-ANNOTATED_FINAL: Final[int]
-
-ANNOTATED_CLASSVAR: int
-
-LITERAL_STR_VAR: LiteralString
-
-BOX_SIZE: Final[int]
-
-BORDER_SIZE: Final[int]
-
 UNANNOTATED_CONST: int
 
 UNANNOTATED_STR: str
@@ -90,11 +80,8 @@ SITE_PROV_VAR: int
 COMMENTED_VAR: int  # pragma: var
 
 def mult(a, b: int): ...
-
 def takes_optional(x): ...
-
 def takes_none_param(x: None) -> None: ...
-
 def _alias_target() -> None: ...
 
 PRIMARY_ALIAS = _alias_target
@@ -102,26 +89,24 @@ PRIMARY_ALIAS = _alias_target
 SECONDARY_ALIAS = _alias_target
 
 def _wrap(fn): ...
-
 def wrapped_with_default(x: int, y: int) -> int: ...
-
 def commented_func(x: int) -> None: ...  # pragma: func
 
 UNTYPED_LAMBDA: function  # noqa: F821
 
 TYPED_LAMBDA: Callable[[int, int], int]
 
-ANNOTATED_EXTRA: Annotated[str, 'extra']
+ANNOTATED_EXTRA: Annotated[str, "extra"]
 
-NESTED_ANNOTATED: Annotated[int, 'a', 'b']
+NESTED_ANNOTATED: Annotated[int, "a", "b"]
 
-TRIPLE_ANNOTATED: Annotated[int, 'x', 'y', 'z']
+TRIPLE_ANNOTATED: Annotated[int, "x", "y", "z"]
 
-ANNOTATED_OPTIONAL_META: Annotated[None | int, 'meta']
+ANNOTATED_OPTIONAL_META: Annotated[None | int, "meta"]
 
-ANNOTATED_FINAL_META: Final[Annotated[int, 'meta']]
+ANNOTATED_FINAL_META: Final[Annotated[int, "meta"]]
 
-ANNOTATED_WRAP_GENERIC: Annotated[list[Annotated[int, 'inner']], 'outer']
+ANNOTATED_WRAP_GENERIC: Annotated[list[Annotated[int, "inner"]], "outer"]
 
 class MetaRepr:
     def __repr__(self) -> str: ...
@@ -137,13 +122,13 @@ class Basic:
     union: int | str
     pipe_union: int | str
     func: Callable[[int, str], bool]
-    annotated: Annotated[int, 'meta']
+    annotated: Annotated[int, "meta"]
     pattern: Pattern[str]
     uid: UserId
-    lit_attr: Literal['a', 'b']
+    lit_attr: Literal["a", "b"]
     def copy[T](self, param: T) -> T: ...
     def curry[**P](self, f: Callable[P, int]) -> Callable[P, int]: ...
-    def literal_method(self, flag: Literal['on', 'off']) -> Literal[1, 0]: ...
+    def literal_method(self, flag: Literal["on", "off"]) -> Literal[1, 0]: ...
     @classmethod
     def cls_method(cls, value: int) -> Basic: ...
     @classmethod
@@ -234,10 +219,8 @@ class GeneratedInt:
 
 @overload
 def over(x: int) -> int: ...
-
 @overload
 def over(x: str) -> str: ...
-
 @dataclass
 class Point:
     x: int
@@ -313,8 +296,8 @@ class Permission(IntFlag):
     EXECUTE = 4
 
 class StrEnum(str, Enum):
-    A = 'a'
-    B = 'b'
+    A = "a"
+    B = "b"
 
 class PointEnum(Enum):
     INLINE = Point(x=1, y=2)
@@ -352,21 +335,13 @@ class Info(TypedDict):
     age: int
 
 def with_kwargs(**kwargs: Unpack[Info]) -> Info: ...
-
 def sum_of(*args: tuple[int]) -> int: ...
-
 def dict_echo(**kwargs: dict[str, Any]) -> dict[str, Any]: ...
-
 def use_params[**P](func: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
-
 def do_nothing() -> None: ...
-
 def always_raises() -> NoReturn: ...
-
 def never_returns() -> Never: ...
-
 def is_str_list(val: list[object]) -> TypeGuard[list[str]]: ...
-
 def is_int(val: object) -> TypeGuard[int]: ...
 
 PLAIN_FINAL_VAR: Final[int]
@@ -388,9 +363,7 @@ def echo_literal(value: LiteralString) -> LiteralString: ...
 NONE_VAR: None
 
 async def async_add_one(x: int) -> int: ...
-
 async def gen_range(n: int) -> AsyncIterator[int]: ...
-
 @final
 class FinalClass: ...
 
@@ -399,24 +372,15 @@ class HasFinalMethod:
     def do_final(self) -> None: ...
 
 def final_func(x: int) -> int: ...
-
 def pragma_func(x: int) -> int: ...  # pyright: ignore
-
 def pos_only_func(a: int, b: str, /) -> None: ...
-
 def kw_only_func(*, x: int, y: str) -> None: ...
-
 def pos_and_kw(a: int, /, b: int, *, c: int) -> None: ...
-
 def iter_sequence(seq: Sequence[int]) -> Iterator[int]: ...
-
 def simple_wrap(fn: Callable[[int], int]) -> Callable[[int], int]: ...
-
 def double_wrapped(x: int) -> int: ...
-
 def cached_add(a: int, b: int) -> int: ...
-
-def annotated_fn(x: Annotated[int, 'inp']) -> Annotated[str, 'out']: ...
+def annotated_fn(x: Annotated[int, "inp"]) -> Annotated[str, "out"]: ...
 
 class FutureClass: ...
 
@@ -433,9 +397,7 @@ class WrappedDescriptors:
     def wrapped_cached(self) -> int: ...
 
 def make_emitter(name: str): ...
-
 def emitted_a(x: int) -> int: ...
-
 def make_emitter_cls(name: str): ...
 
 class EmittedCls:
@@ -447,20 +409,16 @@ class FixedModuleCls: ...
 
 class EmittedMap:
     @overload
-    def __getitem__(self, key: Literal['a']) -> Literal[1]: ...
+    def __getitem__(self, key: Literal["a"]) -> Literal[1]: ...
     @overload
-    def __getitem__(self, key: Literal['b']) -> Literal[2]: ...
+    def __getitem__(self, key: Literal["b"]) -> Literal[2]: ...
 
 def path_passthrough(p: Path) -> Path: ...
-
 @overload
 def loop_over(x: bytearray) -> str: ...
-
 @overload
 def loop_over(x: bytes) -> str: ...
-
 def identity[T](x: T) -> T: ...
-
 def as_tuple[*Ts](*args: Unpack[Ts]) -> tuple[Unpack[Ts]]: ...
 
 class Variadic[*Ts]:
@@ -469,25 +427,18 @@ class Variadic[*Ts]:
 
 @overload
 def times_two(val: Literal[3], factor: Literal[2]) -> Literal[6]: ...
-
 @overload
 def times_two(val: int, factor: int) -> int: ...
-
 @overload
 def bool_gate(flag: Literal[True]) -> Literal[1]: ...
-
 @overload
 def bool_gate(flag: Literal[False]) -> Literal[0]: ...
-
 @overload
 def bool_gate(flag: bool) -> int: ...
-
 @overload
 def mixed_overload(x: str) -> str: ...
-
 @overload
 def mixed_overload(x: Literal[0]) -> Literal[0]: ...
-
 @overload
 def mixed_overload(x: int | str) -> int | str: ...
 
@@ -586,12 +537,6 @@ class RequiredUndefinedCls:
 
 def wrapped_callable(x: int, y: str) -> str: ...
 
-SET_LIST_VAR: set[list[str]]
-
-TUPLE_LIST_VAR: tuple[list[str], int]
-
-CALLABLE_LIST_VAR: list[Callable[[int], str]]
-
 STRICT_UNION: int | str
 
 GENERIC_DEQUE: deque[int]
@@ -599,6 +544,8 @@ GENERIC_DEQUE: deque[int]
 GENERIC_DEQUE_LIST: deque[list[str]]
 
 GENERIC_USERBOX: UserBox[int]
+
+LITERAL_STR_VAR: LiteralString
 
 DICT_WITH_IMPLICIT_ANY: dict[int]  # type: ignore[type-arg]  # pyright: ignore[reportInvalidTypeArguments]
 

--- a/tests/annotations_13.pyi
+++ b/tests/annotations_13.pyi
@@ -2,7 +2,20 @@
 # Do not edit by hand
 from typing import Callable
 
-def overly_generic[SimpleTypeVar, TypeVarWithBound: int, TypeVarWithConstraints: (str, bytes), TypeVarWithDefault = int, *SimpleTypeVarTuple = (int, float), **SimpleParamSpec = (str, bytearray)](a: SimpleTypeVar, b: TypeVarWithDefault, c: TypeVarWithBound, d: Callable[SimpleParamSpec, TypeVarWithConstraints], *e: SimpleTypeVarTuple) -> None: ...
+def overly_generic[
+    SimpleTypeVar,
+    TypeVarWithBound: int,
+    TypeVarWithConstraints: (str, bytes),
+    TypeVarWithDefault = int,
+    *SimpleTypeVarTuple = (int, float),
+    **SimpleParamSpec = (str, bytearray),
+](
+    a: SimpleTypeVar,
+    b: TypeVarWithDefault,
+    c: TypeVarWithBound,
+    d: Callable[SimpleParamSpec, TypeVarWithConstraints],
+    *e: SimpleTypeVarTuple,
+) -> None: ...
 
 type DefaultList[T = int] = list[T]
 

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -3,6 +3,7 @@ from typing import (
     Callable,
     Concatenate,
     Final,
+    Literal,
     NewType,
     ParamSpec,
     TypeAlias,
@@ -110,6 +111,22 @@ TUPLE_VAR: tuple[int, ...]
 # Variable using set and frozenset types to test container formatting
 SET_VAR: set[int]
 FROZENSET_VAR: frozenset[str]
+# Set containing a nested list to exercise TypeNode in set elements
+SET_LIST_VAR: set[list[str]]
+# Tuple containing a nested list to exercise TypeNode in tuple items
+TUPLE_LIST_VAR: tuple[list[str], int]
+# List containing a callable to exercise TypeNode in callable parts
+CALLABLE_LIST_VAR: list[Callable[[int], str]]
+# Edge case: annotated constants with values should honor the annotation
+ANNOTATED_FINAL: Final[int] = 5
+ANNOTATED_CLASSVAR: int = 1
+
+# Literal string should retain quotes
+LITERAL_STR_VAR: Literal["hi"] = "hi"
+
+# ``Final`` without explicit type should infer from value
+BOX_SIZE: Final = 20
+BORDER_SIZE: Final = 4
 
 
 class FutureClass: ...

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -1,7 +1,18 @@
 # Generated via: macrotype tests/annotations_new.py --modules -o tests/annotations_new.pyi
 # Do not edit by hand
-# fmt: off
-from typing import Any, Callable, Concatenate, Final, Literal, NewType, ParamSpec, TypeVar, TypeVarTuple, Unpack, overload
+from typing import (
+    Any,
+    Callable,
+    Concatenate,
+    Final,
+    Literal,
+    NewType,
+    ParamSpec,
+    TypeVar,
+    TypeVarTuple,
+    Unpack,
+    overload,
+)
 
 P = ParamSpec("P")
 
@@ -21,22 +32,18 @@ TDV = TypeVar("TDV")
 
 UserId = NewType("UserId", int)
 
-def with_paramspec_args_kwargs[**P](fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
-
+def with_paramspec_args_kwargs[**P](
+    fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs
+) -> int: ...
 def prepend_one[**P](fn: Callable[Concatenate[int, P], int]) -> Callable[P, int]: ...
-
 @overload
 def special_neg(val: Literal[0]) -> Literal[0]: ...
-
 @overload
 def special_neg(val: Literal[1]) -> Literal[-1]: ...
-
 @overload
 def special_neg(val: int) -> int: ...
-
 @overload
 def parse_int_or_none(val: None) -> None: ...
-
 @overload
 def parse_int_or_none(val: None | str) -> None | int: ...
 
@@ -80,8 +87,17 @@ type TupleUnpackFirst[*Ts] = tuple[Unpack[Ts], int]  # Unpack before trailing el
 
 type RecursiveList[T] = T | list[RecursiveList[T]]
 
-class FutureClass:
-    ...
+ANNOTATED_FINAL: Final[int]
+
+ANNOTATED_CLASSVAR: int
+
+LITERAL_STR_VAR: Literal["hi"]
+
+BOX_SIZE: Final[int]
+
+BORDER_SIZE: Final[int]
+
+class FutureClass: ...
 
 GLOBAL: int
 
@@ -102,3 +118,9 @@ TUPLE_VAR: tuple[int, ...]
 SET_VAR: set[int]
 
 FROZENSET_VAR: frozenset[str]
+
+SET_LIST_VAR: set[list[str]]
+
+TUPLE_LIST_VAR: tuple[list[str], int]
+
+CALLABLE_LIST_VAR: list[Callable[[int], str]]

--- a/tests/typechecking.pyi
+++ b/tests/typechecking.pyi
@@ -1,4 +1,5 @@
 from math import cos
+
 from tests.annotations import Basic
 
 COS_ALIAS = cos


### PR DESCRIPTION
## Summary
- move nested container and Final constant tests into the modules-based annotations suite
- teach modules pipeline to infer simple constant types, including bare `Final`
- allow type resolver/normalizer to handle missing inner types

## Testing
- `ruff check tests/annotations_new.py tests/annotations_new.pyi tests/annotations.py tests/annotations.pyi macrotype/types/resolve.py macrotype/types/normalize.py macrotype/modules/__init__.py macrotype/modules/transformers/constant.py --fix`
- `pytest tests/modules/test_emit_annotations.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0013930108329b86cbfa1dcef685b