### PR TITLE
Move Annotated tests and fix module pipeline

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -226,7 +226,7 @@ def stringify_annotation(ann: Any, name_map: dict[int, str]) -> str:
         first, *metas = args
         parts = [stringify_annotation(first, name_map)]
         for meta in metas:
-            parts.append(name_map.get(id(meta), _qualname(meta)))
+            parts.append(_qualname(meta))
         return f"Annotated[{', '.join(parts)}]"
 
     if origin is tuple and ann is not tuple and not args:

--- a/macrotype/types/normalize.py
+++ b/macrotype/types/normalize.py
@@ -53,6 +53,7 @@ def norm(t: ResolvedTy | Ty, opts: NormOpts | None = None) -> NormalizedTy:
     return NormalizedTy(
         TyRoot(
             ty=inner,
+            annotations=top.annotations,
             is_final=top.is_final,
             is_required=top.is_required,
             is_classvar=top.is_classvar,

--- a/macrotype/types/resolve.py
+++ b/macrotype/types/resolve.py
@@ -49,6 +49,7 @@ def resolve(t: ParsedTy | Ty, env: ResolveEnv) -> ResolvedTy:
     return ResolvedTy(
         TyRoot(
             ty=inner,
+            annotations=top.annotations,
             is_final=top.is_final,
             is_required=top.is_required,
             is_classvar=top.is_classvar,

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -65,28 +65,6 @@ ContravariantT = TypeVar("ContravariantT", contravariant=True)
 TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
 
-# Nested Annotated usage should merge metadata
-NESTED_ANNOTATED: Annotated[Annotated[int, "a"], "b"] = 3
-# Triple-nested Annotated should preserve structure
-TRIPLE_ANNOTATED: Annotated[Annotated[Annotated[int, "x"], "y"], "z"] = 4
-# Annotated union to ensure metadata is preserved with unions
-ANNOTATED_OPTIONAL_META: Annotated[int | None, "meta"] = 0
-# Annotated combined with Final wrapper to verify root handling
-ANNOTATED_FINAL_META: Annotated[Final[int], "meta"] = 2
-# Outer Annotated around a generic with inner Annotated element
-ANNOTATED_WRAP_GENERIC: Annotated[list[Annotated[int, "inner"]], "outer"] = []
-
-
-# Annotated metadata using arbitrary object to verify pass-through
-class MetaRepr:
-    def __repr__(self) -> str:  # pragma: no cover - simple repr
-        return "MetaRepr()"
-
-
-META_REPR = MetaRepr()
-ANNOTATED_OBJ_META: Annotated[int, META_REPR] = 0
-
-# Built-in generic without dedicated handler
 GENERIC_DEQUE: Deque[int]
 # Deque with nested list to exercise TypeNode inside GenericNode
 GENERIC_DEQUE_LIST: Deque[list[str]]

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -57,21 +57,6 @@ TDV = TypeVar("TDV")
 
 UserId = NewType("UserId", int)
 
-NESTED_ANNOTATED: Annotated[int, "a", "b"]
-
-TRIPLE_ANNOTATED: Annotated[int, "x", "y", "z"]
-
-ANNOTATED_OPTIONAL_META: Annotated[None | int, "meta"]
-
-ANNOTATED_FINAL_META: Final[Annotated[int, "meta"]]
-
-ANNOTATED_WRAP_GENERIC: Annotated[list[Annotated[int, "inner"]], "outer"]
-
-class MetaRepr:
-    def __repr__(self) -> str: ...
-
-ANNOTATED_OBJ_META: Annotated[int, MetaRepr()]
-
 class UserBox[T]: ...
 
 class Basic:

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -30,6 +30,28 @@ TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
 
 
+# Nested Annotated usage should merge metadata
+NESTED_ANNOTATED: Annotated[Annotated[int, "a"], "b"] = 3
+# Triple-nested Annotated should preserve structure
+TRIPLE_ANNOTATED: Annotated[Annotated[Annotated[int, "x"], "y"], "z"] = 4
+# Annotated union to ensure metadata is preserved with unions
+ANNOTATED_OPTIONAL_META: Annotated[int | None, "meta"] = 0
+# Annotated combined with Final wrapper to verify root handling
+ANNOTATED_FINAL_META: Annotated[Final[int], "meta"] = 2
+# Outer Annotated around a generic with inner Annotated element
+ANNOTATED_WRAP_GENERIC: Annotated[list[Annotated[int, "inner"]], "outer"] = []
+
+
+# Annotated metadata using arbitrary object to verify pass-through
+class MetaRepr:
+    def __repr__(self) -> str:  # pragma: no cover - simple repr
+        return "MetaRepr()"
+
+
+META_REPR = MetaRepr()
+ANNOTATED_OBJ_META: Annotated[int, META_REPR] = 0
+
+
 def with_paramspec_args_kwargs(fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
 
 

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -33,6 +33,21 @@ TDV = TypeVar("TDV")
 
 UserId = NewType("UserId", int)
 
+NESTED_ANNOTATED: Annotated[int, "a", "b"]
+
+TRIPLE_ANNOTATED: Annotated[int, "x", "y", "z"]
+
+ANNOTATED_OPTIONAL_META: Annotated[int | None, "meta"]
+
+ANNOTATED_FINAL_META: Final[Annotated[int, "meta"]]
+
+ANNOTATED_WRAP_GENERIC: Annotated[list[Annotated[int, "inner"]], "outer"]
+
+class MetaRepr:
+    def __repr__(self) -> str: ...  # pragma: no cover - simple repr
+
+ANNOTATED_OBJ_META: Annotated[int, MetaRepr()]
+
 def with_paramspec_args_kwargs[**P](
     fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs
 ) -> int: ...
@@ -139,7 +154,7 @@ def commented_func(x: int) -> None: ...  # pragma: func
 def UNTYPED_LAMBDA(x, y): ...  # noqa: F821
 def TYPED_LAMBDA(a, b): ...
 
-ANNOTATED_EXTRA: str
+ANNOTATED_EXTRA: Annotated[str, "extra"]
 
 GLOBAL: int
 


### PR DESCRIPTION
## Summary
- migrate initial Annotated metadata tests into `annotations_new`
- keep Annotated metadata through module pipeline by preserving annotations during normalization and emitting metadata with `Annotated`
- refine module scanner to include TypeVars, NewTypes, generic aliases and decorated callables while skipping internal helpers

## Testing
- `pytest`
- `ruff format tests/annotations.py tests/annotations.pyi tests/annotations_new.py tests/annotations_new.pyi macrotype/modules/emit.py macrotype/modules/scanner.py macrotype/types/resolve.py macrotype/types/normalize.py`
- `ruff check --fix tests/annotations.py tests/annotations.pyi tests/annotations_new.py tests/annotations_new.pyi macrotype/modules/emit.py macrotype/modules/scanner.py macrotype/types/resolve.py macrotype/types/normalize.py`

------
https://chatgpt.com/codex/tasks/task_e_68a01b70adbc8329ac0e31d481ac2b5c