### PR TITLE
Support typing.Deque in strict modules pipeline

### DIFF
--- a/macrotype/types/unparse.py
+++ b/macrotype/types/unparse.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 from dataclasses import replace
 from types import EllipsisType
-from typing import Any
+from typing import Any, get_origin
 
 from .ir import (
     Ty,
@@ -80,10 +80,11 @@ def _unparse_no_annos(n: Ty) -> Any:
             return res
         case TyApp(base=base, args=args):
             b = _unparse(base)
+            origin = get_origin(b) or b
             a_objs = tuple(_unparse(a) for a in args)
             if len(a_objs) == 1:
-                return b[a_objs[0]]
-            return b[a_objs]
+                return origin[a_objs[0]]
+            return origin[a_objs]
         case TyLiteral(values=vals):
             return t.Literal[vals]
         case TyCallable(params=ps, ret=r):

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -17,7 +17,6 @@ from typing import (
     Any,
     Callable,
     ClassVar,
-    Deque,
     Final,
     Generic,
     Literal,
@@ -64,18 +63,6 @@ CovariantT = TypeVar("CovariantT", covariant=True)
 ContravariantT = TypeVar("ContravariantT", contravariant=True)
 TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
-
-GENERIC_DEQUE: Deque[int]
-# Deque with nested list to exercise TypeNode inside GenericNode
-GENERIC_DEQUE_LIST: Deque[list[str]]
-
-
-# User-defined generic class to exercise GenericNode
-class UserBox(Generic[T]):
-    pass
-
-
-GENERIC_USERBOX: UserBox[int]
 
 
 class Basic:

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -3,7 +3,6 @@
 # pyright: basic
 # mypy: allow-any-expr
 from abc import ABC, abstractmethod
-from collections import deque
 from collections.abc import AsyncIterator, Iterator, Sequence
 from dataclasses import InitVar, dataclass
 from enum import Enum, IntEnum, IntFlag
@@ -56,8 +55,6 @@ ContravariantT = TypeVar("ContravariantT", contravariant=True)
 TDV = TypeVar("TDV")
 
 UserId = NewType("UserId", int)
-
-class UserBox[T]: ...
 
 class Basic:
     simple: list[str]
@@ -481,12 +478,6 @@ class RequiredUndefinedCls:
 
 def _wrap(fn): ...
 def wrapped_callable(x: int, y: str) -> str: ...
-
-GENERIC_DEQUE: deque[int]
-
-GENERIC_DEQUE_LIST: deque[list[str]]
-
-GENERIC_USERBOX: UserBox[int]
 
 LITERAL_STR_VAR: LiteralString
 

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -4,7 +4,9 @@ from typing import (
     Any,
     Callable,
     Concatenate,
+    Deque,
     Final,
+    Generic,
     Literal,
     NewType,
     ParamSpec,
@@ -28,6 +30,18 @@ CovariantT = TypeVar("CovariantT", covariant=True)
 ContravariantT = TypeVar("ContravariantT", contravariant=True)
 TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
+
+GENERIC_DEQUE: Deque[int]
+# Deque with nested list to exercise TypeNode inside GenericNode
+GENERIC_DEQUE_LIST: Deque[list[str]]
+
+
+# User-defined generic class to exercise GenericNode
+class UserBox(Generic[T]):
+    pass
+
+
+GENERIC_USERBOX: UserBox[int]
 
 
 # Nested Annotated usage should merge metadata

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -1,5 +1,6 @@
 # Generated via: macrotype tests/annotations_new.py --modules -o tests/annotations_new.pyi
 # Do not edit by hand
+from collections import deque
 from typing import (
     Annotated,
     Any,
@@ -32,6 +33,8 @@ ContravariantT = TypeVar("ContravariantT", contravariant=True)
 TDV = TypeVar("TDV")
 
 UserId = NewType("UserId", int)
+
+class UserBox[T]: ...
 
 NESTED_ANNOTATED: Annotated[int, "a", "b"]
 
@@ -155,6 +158,12 @@ def UNTYPED_LAMBDA(x, y): ...  # noqa: F821
 def TYPED_LAMBDA(a, b): ...
 
 ANNOTATED_EXTRA: Annotated[str, "extra"]
+
+GENERIC_DEQUE: deque[int]
+
+GENERIC_DEQUE_LIST: deque[list[str]]
+
+GENERIC_USERBOX: UserBox[int]
 
 GLOBAL: int
 

--- a/tests/modules/test_emit_annotations.py
+++ b/tests/modules/test_emit_annotations.py
@@ -48,8 +48,8 @@ def test_emit_annotations_headers_and_imports() -> None:
     assert lines[1] == "# mypy: allow-any-expr"
     expected_imports = [
         "from abc import ABC, abstractmethod",
-        "from collections import deque",
         "from collections.abc import AsyncIterator, Iterator, Sequence",
+        "from dataclasses import InitVar, dataclass",
     ]
     assert lines[2:5] == expected_imports
 


### PR DESCRIPTION
## Summary
- move Deque and UserBox tests from annotations.py to annotations_new.py
- resolve typing special generics using get_origin in unparse

## Testing
- `ruff format tests/annotations.py tests/annotations_new.py macrotype/types/unparse.py`
- `ruff check --fix tests/annotations.py tests/annotations_new.py macrotype/types/unparse.py`
- `pytest tests/test_all.py::test_stub_generation_matches_expected -q`
- `pytest tests/modules/test_ir.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a020b2683483299e81e42f94ea424c