### PR TITLE
Allow Unpack in kwargs annotations

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -20,15 +20,11 @@ from typing import (
     NewType,
     NoReturn,
     ParamSpec,
-    Protocol,
-    Self,
-    TypedDict,
     TypeGuard,
     TypeVar,
     TypeVarTuple,
     Unpack,
     final,
-    runtime_checkable,
 )
 
 import macrotype.meta_types as mt
@@ -52,47 +48,6 @@ CovariantT = TypeVar("CovariantT", covariant=True)
 ContravariantT = TypeVar("ContravariantT", contravariant=True)
 TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
-
-
-class SelfExample:
-    def clone(self: Self) -> Self:
-        return self
-
-
-class SelfFactory:
-    def __init__(self, value: int) -> None:
-        self.value = value
-
-    @classmethod
-    def create(cls: type[Self], value: int) -> Self:
-        return cls(value)
-
-
-@runtime_checkable
-class Runnable(Protocol):
-    def run(self) -> int: ...
-
-
-# runtime_checkable applied after class definition should be preserved
-class LaterRunnable(Protocol):
-    def run(self) -> int: ...
-
-
-LaterRunnable = runtime_checkable(LaterRunnable)
-
-
-# Protocol auto methods should be pruned
-class NoProtoMethods(Protocol):
-    pass
-
-
-class Info(TypedDict):
-    name: str
-    age: int
-
-
-def with_kwargs(**kwargs: Unpack[Info]) -> Info:
-    return kwargs
 
 
 def sum_of(*args: tuple[int]) -> int:

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -18,16 +18,12 @@ from typing import (
     NewType,
     NoReturn,
     ParamSpec,
-    Protocol,
-    Self,
-    TypedDict,
     TypeGuard,
     TypeVar,
     TypeVarTuple,
     Unpack,
     final,
     overload,
-    runtime_checkable,
 )
 
 T = TypeVar("T")
@@ -48,29 +44,6 @@ TDV = TypeVar("TDV")
 
 UserId = NewType("UserId", int)
 
-class SelfExample:
-    def clone(self: Self) -> Self: ...
-
-class SelfFactory:
-    def __init__(self, value: int) -> None: ...
-    @classmethod
-    def create(cls: type[Self], value: int) -> Self: ...
-
-@runtime_checkable
-class Runnable(Protocol):
-    def run(self) -> int: ...
-
-@runtime_checkable
-class LaterRunnable(Protocol):
-    def run(self) -> int: ...
-
-class NoProtoMethods(Protocol): ...
-
-class Info(TypedDict):
-    name: str
-    age: int
-
-def with_kwargs(**kwargs: Unpack[Info]) -> Info: ...
 def sum_of(*args: tuple[int]) -> int: ...
 def dict_echo(**kwargs: dict[str, Any]) -> dict[str, Any]: ...
 def use_params[**P](func: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -17,7 +17,9 @@ from typing import (
     NotRequired,
     Optional,
     ParamSpec,
+    Protocol,
     Required,
+    Self,
     TypeAlias,
     TypeAliasType,
     TypedDict,
@@ -27,6 +29,7 @@ from typing import (
     Unpack,
     overload,
     override,
+    runtime_checkable,
 )
 
 from macrotype.meta_types import overload_for
@@ -41,6 +44,48 @@ CovariantT = TypeVar("CovariantT", covariant=True)
 ContravariantT = TypeVar("ContravariantT", contravariant=True)
 TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
+
+
+# Self and runtime checkable protocol examples
+class SelfExample:
+    def clone(self: Self) -> Self:
+        return self
+
+
+class SelfFactory:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    @classmethod
+    def create(cls: type[Self], value: int) -> Self:
+        return cls(value)
+
+
+@runtime_checkable
+class Runnable(Protocol):
+    def run(self) -> int: ...
+
+
+# runtime_checkable applied after class definition should be preserved
+class LaterRunnable(Protocol):
+    def run(self) -> int: ...
+
+
+LaterRunnable = runtime_checkable(LaterRunnable)
+
+
+# Protocol auto methods should be pruned
+class NoProtoMethods(Protocol):
+    pass
+
+
+class Info(TypedDict):
+    name: str
+    age: int
+
+
+def with_kwargs(**kwargs: Unpack[Info]) -> Info:
+    return kwargs
 
 
 # Property with both setter and deleter

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -16,13 +16,16 @@ from typing import (
     NewType,
     NotRequired,
     ParamSpec,
+    Protocol,
     Required,
+    Self,
     TypedDict,
     TypeVar,
     TypeVarTuple,
     Unpack,
     overload,
     override,
+    runtime_checkable,
 )
 
 P = ParamSpec("P")
@@ -42,6 +45,30 @@ ContravariantT = TypeVar("ContravariantT", contravariant=True)
 TDV = TypeVar("TDV")
 
 UserId = NewType("UserId", int)
+
+class SelfExample:
+    def clone(self: Self) -> Self: ...
+
+class SelfFactory:
+    def __init__(self, value: int) -> None: ...
+    @classmethod
+    def create(cls: type[Self], value: int) -> Self: ...
+
+@runtime_checkable
+class Runnable(Protocol):
+    def run(self) -> int: ...
+
+@runtime_checkable
+class LaterRunnable(Protocol):
+    def run(self) -> int: ...
+
+class NoProtoMethods(Protocol): ...
+
+class Info(TypedDict):
+    name: str
+    age: int
+
+def with_kwargs(**kwargs: Unpack[Info]) -> Info: ...
 
 class ManualProperty:
     @property


### PR DESCRIPTION
## Summary
- move Self and runtime-checkable protocol tests from `annotations.py` to `annotations_new.py`
- permit `Unpack[...]` in parameter annotations within the modules type validator
- regenerate annotation stubs

## Testing
- `ruff format tests/annotations_new.py tests/annotations.py macrotype/types/validate.py`
- `ruff check --fix tests/annotations_new.py tests/annotations.py macrotype/types/validate.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a07a9f8a2c8329b1062b49377afaa1