### PR TITLE
Handle async functions in modules pipeline

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -294,7 +294,7 @@ def _emit_decl(sym: Decl, name_map: dict[int, str], *, indent: int) -> list[str]
             line = _add_comment(line, sym.comment or site.comment)
             return [line]
 
-        case FuncDecl(params=params, ret=ret, decorators=decos, type_params=tp):
+        case FuncDecl(params=params, ret=ret, decorators=decos, type_params=tp, is_async=is_async):
             pieces: list[str] = []
             for d in decos:
                 pieces.append(f"{pad}@{d}")
@@ -310,7 +310,8 @@ def _emit_decl(sym: Decl, name_map: dict[int, str], *, indent: int) -> list[str]
                     param_strs.append(f"{name}: {stringify_annotation(p.annotation, name_map)}")
             ret_str = f" -> {stringify_annotation(ret.annotation, name_map)}" if ret else ""
             tp_str = f"[{', '.join(tp)}]" if tp else ""
-            line = f"{pad}def {sym.name}{tp_str}({', '.join(param_strs)}){ret_str}: ..."
+            prefix = "async " if is_async else ""
+            line = f"{pad}{prefix}def {sym.name}{tp_str}({', '.join(param_strs)}){ret_str}: ..."
             line = _add_comment(line, sym.comment)
             pieces.append(line)
             return pieces

--- a/macrotype/modules/ir.py
+++ b/macrotype/modules/ir.py
@@ -53,6 +53,7 @@ class FuncDecl(Decl):
     decorators: tuple[str, ...] = ()
     type_params: tuple[str, ...] = ()
     flags: dict[str, bool] = field(default_factory=dict)  # e.g., staticmethod, classmethod
+    is_async: bool = False
 
     def get_annotation_sites(self) -> tuple[Site, ...]:
         sites = list(self.params)

--- a/macrotype/modules/scanner.py
+++ b/macrotype/modules/scanner.py
@@ -127,12 +127,15 @@ def _scan_function(fn: t.Callable) -> FuncDecl:
     if getattr(fn, "__isabstractmethod__", False):
         decos.append("abstractmethod")
 
+    is_async = inspect.iscoroutinefunction(fn) or inspect.isasyncgenfunction(fn)
+
     return FuncDecl(
         name=name.split(".")[-1],
         params=tuple(params),
         ret=ret,
         obj=fn,
         decorators=tuple(decos),
+        is_async=is_async,
     )
 
 

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -2,7 +2,6 @@
 # mypy: allow-any-expr
 import collections.abc as cabc
 import functools
-import math
 import sys
 import types
 import typing
@@ -18,11 +17,9 @@ from typing import (
     LiteralString,
     NewType,
     ParamSpec,
-    TypeGuard,
     TypeVar,
     TypeVarTuple,
     Unpack,
-    final,
 )
 
 import macrotype.meta_types as mt
@@ -48,87 +45,11 @@ TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
 
 
-# Edge case: ``Concatenate`` parameter handling
 # Edge case: ``Concatenate`` parameter handling (requires PEP 695 generics)
-
-
-# Edge case: direct use of ``P.args`` and ``P.kwargs``
-# Edge case: ``TypeGuard`` return type
-def is_str_list(val: list[object]) -> TypeGuard[list[str]]:
-    return all(isinstance(v, str) for v in val)
-
-
-# Additional TypeGuard example
-def is_int(val: object) -> TypeGuard[int]:
-    return isinstance(val, int)
 
 
 # Edge case: LiteralString handling
 LITERAL_STR_VAR: LiteralString
-
-# Edge case: ``Final`` annotated variable with a value
-PLAIN_FINAL_VAR: Final[int] = 1
-
-# Edge case: alias to a foreign function should be preserved
-SIN_ALIAS = math.sin
-
-# Foreign function with annotation should stay a variable
-COS_VAR: Callable[[float], float] = math.cos
-
-# Edge case: alias to a foreign constant should retain its type
-PI_ALIAS = math.pi
-
-# Variable with pragma comment should retain comment in stub
-PRAGMA_VAR = 1  # type: ignore
-
-
-def local_alias_target(x: int) -> int:
-    return x
-
-
-# Edge case: alias to a local function should be preserved
-LOCAL_ALIAS = local_alias_target
-
-
-def echo_literal(value: LiteralString) -> LiteralString:
-    return value
-
-
-# Edge case: variable annotated as ``None``
-NONE_VAR: None = None
-
-
-# Edge case: async function
-async def async_add_one(x: int) -> int:
-    return x + 1
-
-
-# Edge case: async generator function
-async def gen_range(n: int) -> cabc.AsyncIterator[int]:
-    for i in range(n):
-        yield i
-
-
-# Edge case: ``final`` decorator handling
-@final
-class FinalClass: ...
-
-
-class HasFinalMethod:
-    @final
-    def do_final(self) -> None:
-        pass
-
-
-@final
-def final_func(x: int) -> int:
-    return x
-
-
-# Function with pragma comment should retain comment in stub
-def pragma_func(x: int) -> int:  # pyright: ignore
-    return x
-
 
 # Dict without explicit value type should remain as written
 DICT_WITH_IMPLICIT_ANY: dict[int]  # type: ignore[type-arg]  # pyright: ignore[reportInvalidTypeArguments]

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -3,9 +3,8 @@
 # pyright: basic
 # mypy: allow-any-expr
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator, Iterator, Sequence
+from collections.abc import Iterator, Sequence
 from functools import cached_property
-from math import sin
 from pathlib import Path
 from typing import (
     Annotated,
@@ -16,11 +15,9 @@ from typing import (
     LiteralString,
     NewType,
     ParamSpec,
-    TypeGuard,
     TypeVar,
     TypeVarTuple,
     Unpack,
-    final,
     overload,
 )
 
@@ -42,38 +39,6 @@ TDV = TypeVar("TDV")
 
 UserId = NewType("UserId", int)
 
-def is_str_list(val: list[object]) -> TypeGuard[list[str]]: ...
-def is_int(val: object) -> TypeGuard[int]: ...
-
-PLAIN_FINAL_VAR: Final[int]
-
-SIN_ALIAS = sin
-
-COS_VAR: Callable[[float], float]
-
-PI_ALIAS: float
-
-PRAGMA_VAR: int  # type: ignore
-
-def local_alias_target(x: int) -> int: ...
-
-LOCAL_ALIAS = local_alias_target
-
-def echo_literal(value: LiteralString) -> LiteralString: ...
-
-NONE_VAR: None
-
-async def async_add_one(x: int) -> int: ...
-async def gen_range(n: int) -> AsyncIterator[int]: ...
-@final
-class FinalClass: ...
-
-class HasFinalMethod:
-    @final
-    def do_final(self) -> None: ...
-
-def final_func(x: int) -> int: ...
-def pragma_func(x: int) -> int: ...  # pyright: ignore
 def pos_only_func(a: int, b: str, /) -> None: ...
 def kw_only_func(*, x: int, y: str) -> None: ...
 def pos_and_kw(a: int, /, b: int, *, c: int) -> None: ...

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -1,4 +1,6 @@
+import collections.abc as cabc
 import functools
+import math
 import re
 from dataclasses import InitVar, dataclass
 from enum import Enum, IntEnum, IntFlag
@@ -13,6 +15,7 @@ from typing import (
     Final,
     Generic,
     Literal,
+    LiteralString,
     Never,
     NewType,
     NoReturn,
@@ -25,10 +28,12 @@ from typing import (
     TypeAlias,
     TypeAliasType,
     TypedDict,
+    TypeGuard,
     TypeVar,
     TypeVarTuple,
     Union,
     Unpack,
+    final,
     overload,
     override,
     runtime_checkable,
@@ -60,6 +65,84 @@ def dict_echo(**kwargs: dict[str, Any]) -> dict[str, Any]:
 # Edge case: direct use of ``P.args`` and ``P.kwargs``
 def use_params(func: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int:
     return func(*args, **kwargs)
+
+
+# Edge case: ``TypeGuard`` return type
+def is_str_list(val: list[object]) -> TypeGuard[list[str]]:
+    return all(isinstance(v, str) for v in val)
+
+
+# Additional TypeGuard example
+def is_int(val: object) -> TypeGuard[int]:
+    return isinstance(val, int)
+
+
+# Edge case: ``Final`` annotated variable with a value
+PLAIN_FINAL_VAR: Final[int] = 1
+
+
+# Edge case: alias to a foreign function should be preserved
+SIN_ALIAS = math.sin
+
+
+# Foreign function with annotation should stay a variable
+COS_VAR: Callable[[float], float] = math.cos
+
+
+# Edge case: alias to a foreign constant should retain its type
+PI_ALIAS = math.pi
+
+
+# Variable with pragma comment should retain comment in stub
+PRAGMA_VAR = 1  # type: ignore
+
+
+def local_alias_target(x: int) -> int:
+    return x
+
+
+# Edge case: alias to a local function should be preserved
+LOCAL_ALIAS = local_alias_target
+
+
+def echo_literal(value: LiteralString) -> LiteralString:
+    return value
+
+
+# Edge case: variable annotated as ``None``
+NONE_VAR: None = None
+
+
+# Edge case: async function
+async def async_add_one(x: int) -> int:
+    return x + 1
+
+
+# Edge case: async generator function
+async def gen_range(n: int) -> cabc.AsyncIterator[int]:
+    for i in range(n):
+        yield i
+
+
+# Edge case: ``final`` decorator handling
+@final
+class FinalClass: ...
+
+
+class HasFinalMethod:
+    @final
+    def do_final(self) -> None:
+        pass
+
+
+@final
+def final_func(x: int) -> int:
+    return x
+
+
+# Function with pragma comment should retain comment in stub
+def pragma_func(x: int) -> int:  # pyright: ignore
+    return x
 
 
 # Edge case: function explicitly returning ``None``

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -1,9 +1,11 @@
 # Generated via: macrotype tests/annotations_new.py --modules -o tests/annotations_new.pyi
 # Do not edit by hand
 from collections import deque
+from collections.abc import AsyncIterator
 from dataclasses import InitVar, dataclass
 from enum import Enum, IntEnum, IntFlag
 from functools import cached_property
+from math import sin
 from re import Pattern
 from typing import (
     Annotated,
@@ -13,6 +15,7 @@ from typing import (
     Concatenate,
     Final,
     Literal,
+    LiteralString,
     Never,
     NewType,
     NoReturn,
@@ -22,9 +25,11 @@ from typing import (
     Required,
     Self,
     TypedDict,
+    TypeGuard,
     TypeVar,
     TypeVarTuple,
     Unpack,
+    final,
     overload,
     override,
     runtime_checkable,
@@ -51,6 +56,38 @@ UserId = NewType("UserId", int)
 def sum_of(*args: tuple[int]) -> int: ...
 def dict_echo(**kwargs: dict[str, Any]) -> dict[str, Any]: ...
 def use_params[**P](func: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
+def is_str_list(val: list[object]) -> TypeGuard[list[str]]: ...
+def is_int(val: object) -> TypeGuard[int]: ...
+
+PLAIN_FINAL_VAR: Final[int]
+
+SIN_ALIAS = sin
+
+COS_VAR: Callable[[float], float]
+
+PI_ALIAS: float
+
+PRAGMA_VAR: int  # type: ignore
+
+def local_alias_target(x: int) -> int: ...
+
+LOCAL_ALIAS = local_alias_target
+
+def echo_literal(value: LiteralString) -> LiteralString: ...
+
+NONE_VAR: None
+
+async def async_add_one(x: int) -> int: ...
+async def gen_range(n: int) -> AsyncIterator[int]: ...
+@final
+class FinalClass: ...
+
+class HasFinalMethod:
+    @final
+    def do_final(self) -> None: ...
+
+def final_func(x: int) -> int: ...
+def pragma_func(x: int) -> int: ...  # pyright: ignore
 def do_nothing() -> None: ...
 def always_raises() -> Never: ...
 def never_returns() -> Never: ...

--- a/tests/modules/test_emit_annotations.py
+++ b/tests/modules/test_emit_annotations.py
@@ -48,7 +48,7 @@ def test_emit_annotations_headers_and_imports() -> None:
     assert lines[1] == "# mypy: allow-any-expr"
     expected_imports = [
         "from abc import ABC, abstractmethod",
-        "from collections.abc import AsyncIterator, Iterator, Sequence",
+        "from collections.abc import Iterator, Sequence",
         "from functools import cached_property",
     ]
     assert lines[2:5] == expected_imports

--- a/tests/modules/test_ir.py
+++ b/tests/modules/test_ir.py
@@ -197,8 +197,8 @@ def test_get_all_decls_includes_nested() -> None:
 
 
 def test_flag_transform() -> None:
-    ann = importlib.import_module("tests.annotations")
-    mi = from_module(ann)
+    ann_new = importlib.import_module("tests.annotations_new")
+    mi = from_module(ann_new)
 
     fc = next(s for s in mi.members if s.name == "FinalClass")
     assert isinstance(fc, ClassDecl)
@@ -215,9 +215,7 @@ def test_flag_transform() -> None:
     assert ff.flags.get("final") is True
     assert "final" not in ff.decorators
 
-    ann_new = importlib.import_module("tests.annotations_new")
-    mi_new = from_module(ann_new)
-    ol = next(s for s in mi_new.members if s.name == "OverrideLate")
+    ol = next(s for s in mi.members if s.name == "OverrideLate")
     assert isinstance(ol, ClassDecl)
     cls_override = next(
         m for m in ol.members if isinstance(m, FuncDecl) and m.name == "cls_override"
@@ -225,7 +223,9 @@ def test_flag_transform() -> None:
     assert cls_override.flags.get("override") is True
     assert "override" in cls_override.decorators
 
-    ab = next(s for s in mi.members if s.name == "AbstractBase")
+    ann_old = importlib.import_module("tests.annotations")
+    mi_old = from_module(ann_old)
+    ab = next(s for s in mi_old.members if s.name == "AbstractBase")
     assert isinstance(ab, ClassDecl)
     assert ab.flags.get("abstract") is True
     m = next(m for m in ab.members if isinstance(m, FuncDecl) and m.name == "do_something")


### PR DESCRIPTION
## Summary
- move TypeGuard, alias, and async tests into annotations_new suite
- teach modules pipeline to track async functions via `is_async`
- refresh module tests for updated imports and moved symbols

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a08170eadc8329bbb2ed89f930b9a5