### PR TITLE
Move initial annotations tests to modules pipeline

### DIFF
--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -2,14 +2,7 @@
 # mypy: allow-any-expr
 import types
 import typing
-from typing import (
-    Any,
-    Final,
-    NewType,
-    ParamSpec,
-    TypeVar,
-    TypeVarTuple,
-)
+from typing import Any, NewType, ParamSpec, TypeVar, TypeVarTuple
 
 import macrotype.meta_types as mt
 
@@ -26,9 +19,6 @@ TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
 
 
-# TypeScript-inspired metaclass utilities
-
-
 def strip_null(ann: Any, null: Any) -> Any:
     origin = typing.get_origin(ann)
     if origin in {typing.Union, types.UnionType}:
@@ -40,57 +30,6 @@ def strip_null(ann: Any, null: Any) -> Any:
             result |= a
         return result
     return ann
-
-
-class Cls:
-    a: int
-    b: float | None
-    c: str | None
-    d: bytes
-
-
-class OptionalCls:
-    __annotations__ = {k: v | None for k, v in mt.all_annotations(Cls).items()}
-
-
-class RequiredCls:
-    __annotations__ = {k: strip_null(v, type(None)) for k, v in mt.all_annotations(Cls).items()}
-
-
-class PickedCls:
-    __annotations__ = {k: v for k, v in mt.all_annotations(Cls).items() if k in {"a", "b"}}
-
-
-class OmittedCls:
-    __annotations__ = {k: v for k, v in mt.all_annotations(Cls).items() if k not in {"c", "d"}}
-
-
-class FinalCls:
-    __annotations__ = {k: Final[v] for k, v in mt.all_annotations(Cls).items()}
-
-
-ReplacedCls = type(
-    "ReplacedCls",
-    (),
-    {"__annotations__": {**mt.all_annotations(Cls), "a": str, "b": bool}},
-)
-
-
-# meta_types with inherited annotations
-class BaseInherit:
-    base: int
-
-
-class SubInherit(BaseInherit):
-    sub: str
-
-
-class InheritedOmit:
-    __annotations__ = {k: v for k, v in mt.all_annotations(SubInherit).items() if k != "sub"}
-
-
-class InheritedFinal:
-    __annotations__ = {k: Final[v] for k, v in mt.all_annotations(SubInherit).items()}
 
 
 # optional() and required() with a custom null sentinel

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -2,7 +2,7 @@
 # Do not edit by hand
 # pyright: basic
 # mypy: allow-any-expr
-from typing import Any, Final, NewType, ParamSpec, TypeVar, TypeVarTuple
+from typing import Any, NewType, ParamSpec, TypeVar, TypeVarTuple
 
 T = TypeVar("T")
 
@@ -23,57 +23,6 @@ TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
 
 def strip_null(ann: Any, null: Any) -> Any: ...
-
-class Cls:
-    a: int
-    b: None | float
-    c: None | str
-    d: bytes
-
-class OptionalCls:
-    a: None | int
-    b: None | float
-    c: None | str
-    d: None | bytes
-
-class RequiredCls:
-    a: int
-    b: float
-    c: str
-    d: bytes
-
-class PickedCls:
-    a: int
-    b: None | float
-
-class OmittedCls:
-    a: int
-    b: None | float
-
-class FinalCls:
-    a: Final[int]
-    b: Final[None | float]
-    c: Final[None | str]
-    d: Final[bytes]
-
-class ReplacedCls:
-    a: str
-    b: bool
-    c: None | str
-    d: bytes
-
-class BaseInherit:
-    base: int
-
-class SubInherit(BaseInherit):
-    sub: str
-
-class InheritedOmit:
-    base: int
-
-class InheritedFinal:
-    base: Final[int]
-    sub: Final[str]
 
 class Undefined: ...
 

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -54,6 +54,59 @@ TDV = TypeVar("TDV")
 
 UserId = NewType("UserId", int)
 
+def strip_null(ann: Any, null: Any) -> Any: ...
+
+class Cls:
+    a: int
+    b: None | float
+    c: None | str
+    d: bytes
+
+class OptionalCls:
+    a: None | int
+    b: None | float
+    c: None | str
+    d: None | bytes
+
+class RequiredCls:
+    a: int
+    b: float
+    c: str
+    d: bytes
+
+class PickedCls:
+    a: int
+    b: None | float
+
+class OmittedCls:
+    a: int
+    b: None | float
+
+class FinalCls:
+    a: Final[int]
+    b: Final[float | None]
+    c: Final[str | None]
+    d: Final[bytes]
+
+class ReplacedCls:
+    a: str
+    b: bool
+    c: None | str
+    d: bytes
+
+class BaseInherit:
+    base: int
+
+class SubInherit(BaseInherit):
+    sub: str
+
+class InheritedOmit:
+    base: int
+
+class InheritedFinal:
+    base: Final[int]
+    sub: Final[str]
+
 def pos_only_func(a: int, b: str) -> None: ...
 def kw_only_func(x: int, y: str) -> None: ...
 def pos_and_kw(a: int, b: int, c: int) -> None: ...

--- a/tests/modules/test_emit_annotations.py
+++ b/tests/modules/test_emit_annotations.py
@@ -46,7 +46,7 @@ def test_emit_annotations_headers_and_imports() -> None:
 
     assert lines[0] == "# pyright: basic"
     assert lines[1] == "# mypy: allow-any-expr"
-    expected_imports = ["from typing import Any, Final, NewType, ParamSpec, TypeVar, TypeVarTuple"]
+    expected_imports = ["from typing import Any, NewType, ParamSpec, TypeVar, TypeVarTuple"]
     assert lines[2:3] == expected_imports
 
 


### PR DESCRIPTION
## Summary
- migrate strip_null and annotation-manipulation tests into `annotations_new`
- keep custom sentinel tests in `annotations` and adjust typing imports
- update header/import expectation for modules pipeline tests

## Testing
- `ruff format tests/annotations.py tests/annotations_new.py tests/annotations.pyi tests/annotations_new.pyi tests/modules/test_emit_annotations.py`
- `ruff check --fix tests/annotations.py tests/annotations_new.py tests/annotations.pyi tests/annotations_new.pyi tests/modules/test_emit_annotations.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0952824a08329b5f487753ed358f9