### PR TITLE
Handle union ordering in modules pipeline

### DIFF
--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -185,7 +185,7 @@ def stringify_annotation(ann: Any, name_map: dict[int, str]) -> str:
 
     if origin in {types.UnionType, t.Union}:
         items = [(arg, stringify_annotation(arg, name_map)) for arg in args]
-        items.sort(key=lambda item: (0 if isinstance(item[0], t.TypeVar) else 1))
+        items.sort(key=lambda item: (0 if isinstance(item[0], t.TypeVar) else 1, item[1]))
         return " | ".join(s for _, s in items)
 
     from collections.abc import Callable as ABC_Callable

--- a/tests/annotations.py
+++ b/tests/annotations.py
@@ -4,8 +4,6 @@ import types
 import typing
 from typing import Any, NewType, ParamSpec, TypeVar, TypeVarTuple
 
-import macrotype.meta_types as mt
-
 T = TypeVar("T")
 P = ParamSpec("P")
 Ts = TypeVarTuple("Ts")
@@ -30,25 +28,6 @@ def strip_null(ann: Any, null: Any) -> Any:
             result |= a
         return result
     return ann
-
-
-# optional() and required() with a custom null sentinel
-class Undefined: ...
-
-
-class UndefinedCls:
-    a: int
-    b: str | Undefined
-
-
-class OptionalUndefinedCls:
-    __annotations__ = {k: v | Undefined for k, v in mt.all_annotations(UndefinedCls).items()}
-
-
-class RequiredUndefinedCls:
-    __annotations__ = {
-        k: strip_null(v, Undefined) for k, v in mt.all_annotations(UndefinedCls).items()
-    }
 
 
 # Callable wrapped by non-function object with __wrapped__

--- a/tests/annotations.pyi
+++ b/tests/annotations.pyi
@@ -23,20 +23,5 @@ TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
 
 def strip_null(ann: Any, null: Any) -> Any: ...
-
-class Undefined: ...
-
-class UndefinedCls:
-    a: int
-    b: Undefined | str
-
-class OptionalUndefinedCls:
-    a: Undefined | int
-    b: Undefined | str
-
-class RequiredUndefinedCls:
-    a: int
-    b: str
-
 def _wrap(fn): ...
 def wrapped_callable(x: int, y: str) -> str: ...

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -129,6 +129,25 @@ class InheritedFinal:
     __annotations__ = {k: Final[v] for k, v in mt.all_annotations(SubInherit).items()}
 
 
+# optional() and required() with a custom null sentinel
+class Undefined: ...
+
+
+class UndefinedCls:
+    a: int
+    b: str | Undefined
+
+
+class OptionalUndefinedCls:
+    __annotations__ = {k: v | Undefined for k, v in mt.all_annotations(UndefinedCls).items()}
+
+
+class RequiredUndefinedCls:
+    __annotations__ = {
+        k: strip_null(v, Undefined) for k, v in mt.all_annotations(UndefinedCls).items()
+    }
+
+
 # Edge case: LiteralString handling
 LITERAL_STR_VAR: LiteralString
 # Dict without explicit value type should remain as written

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -84,8 +84,8 @@ class OmittedCls:
 
 class FinalCls:
     a: Final[int]
-    b: Final[float | None]
-    c: Final[str | None]
+    b: Final[None | float]
+    c: Final[None | str]
     d: Final[bytes]
 
 class ReplacedCls:
@@ -106,6 +106,20 @@ class InheritedOmit:
 class InheritedFinal:
     base: Final[int]
     sub: Final[str]
+
+class Undefined: ...
+
+class UndefinedCls:
+    a: int
+    b: Undefined | str
+
+class OptionalUndefinedCls:
+    a: Undefined | int
+    b: Undefined | str
+
+class RequiredUndefinedCls:
+    a: int
+    b: str
 
 def pos_only_func(a: int, b: str) -> None: ...
 def kw_only_func(x: int, y: str) -> None: ...
@@ -401,7 +415,7 @@ NESTED_ANNOTATED: Annotated[int, "a", "b"]
 
 TRIPLE_ANNOTATED: Annotated[int, "x", "y", "z"]
 
-ANNOTATED_OPTIONAL_META: Annotated[int | None, "meta"]
+ANNOTATED_OPTIONAL_META: Annotated[None | int, "meta"]
 
 ANNOTATED_FINAL_META: Final[Annotated[int, "meta"]]
 

--- a/tests/modules/test_emit.py
+++ b/tests/modules/test_emit.py
@@ -138,7 +138,7 @@ case4 = (
         "",
         "nested: list[Callable[[int], str]]",
         "",
-        "combo: Callable[[int], str] | Callable[..., bool]",
+        "combo: Callable[..., bool] | Callable[[int], str]",
     ],
 )
 


### PR DESCRIPTION
## Summary
- move custom undefined optional/required tests to modules-driven annotations suite
- sort union members deterministically by name in modules pipeline
- adjust module emission tests for new union ordering

## Testing
- `python -m macrotype tests/annotations.py -o tests/annotations.pyi`
- `python -m macrotype tests/annotations_new.py --modules -o tests/annotations_new.pyi`
- `ruff format tests/annotations_new.py tests/annotations.py macrotype/modules/emit.py tests/annotations.pyi tests/annotations_new.pyi`
- `ruff check --fix tests/annotations_new.py tests/annotations.py macrotype/modules/emit.py tests/annotations.pyi tests/annotations_new.pyi`
- `ruff format tests/modules/test_emit.py`
- `ruff check --fix tests/modules/test_emit.py`
- `pytest tests/modules/test_emit.py::test_emit_module_table -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c589d7cc8329b8e6dc7a143f48ea