### PR TITLE
Fix patch_typing cleanup when typing lacks get_overloads

### DIFF
--- a/macrotype/meta_types.py
+++ b/macrotype/meta_types.py
@@ -75,6 +75,8 @@ def patch_typing():
         typing.overload = orig_overload
         if orig_get is not None:
             typing.get_overloads = orig_get
+        elif hasattr(typing, "get_overloads"):
+            del typing.get_overloads
 
         new = {mod: dict(funcs) for mod, funcs in _OVERLOAD_REGISTRY.items()}
         _OVERLOAD_REGISTRY.clear()

--- a/tests/test_meta_types.py
+++ b/tests/test_meta_types.py
@@ -16,3 +16,14 @@ def test_patch_typing_updates_typing_registry():
     clear_registry()
     assert typing.get_overloads(local) == []
     assert get_overloads(local) == []
+
+
+def test_patch_typing_restores_missing_get_overloads():
+    orig = typing.get_overloads
+    del typing.get_overloads
+    try:
+        with patch_typing():
+            pass
+        assert not hasattr(typing, "get_overloads")
+    finally:
+        typing.get_overloads = orig


### PR DESCRIPTION
## Summary
- ensure `patch_typing` removes temporary `typing.get_overloads` when the original module lacks it
- add regression test for `patch_typing` cleanup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a126175fd08329a677e42d507fe7e4