### PR TITLE
Fix override/final decorator ordering in emitted stubs

### DIFF
--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -1041,6 +1041,19 @@ class OverrideLate(Basic):
         return 2
 
 
+# Edge case: @override applied before descriptor
+class OverrideEarly(Basic):
+    @classmethod
+    @override
+    def cls_override(cls) -> int:
+        return 3
+
+    @staticmethod
+    @override
+    def static_override() -> int:
+        return 4
+
+
 # Callable wrapped by non-function object with __wrapped__
 def _wrap(fn):
     class Wrapper:

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -582,11 +582,19 @@ class OverrideChild(Basic):
     def copy[T](self, param: T) -> T: ...
 
 class OverrideLate(Basic):
+    @override
     @classmethod
-    @override
     def cls_override(cls) -> int: ...
-    @staticmethod
     @override
+    @staticmethod
+    def static_override() -> int: ...
+
+class OverrideEarly(Basic):
+    @override
+    @classmethod
+    def cls_override(cls) -> int: ...
+    @override
+    @staticmethod
     def static_override() -> int: ...
 
 def wrapped_callable(x: int, y: str) -> str: ...


### PR DESCRIPTION
## Summary
- ensure final/override/abstractmethod decorators precede descriptors in generated stubs
- add regression tests for override before/after classmethod/staticmethod

## Testing
- `ruff format macrotype/modules/transformers/flag.py tests/annotations_new.py tests/annotations_new.pyi`
- `ruff check macrotype/modules/transformers/flag.py tests/annotations_new.py tests/annotations_new.pyi --fix`
- `python -m macrotype tests/annotations_new.py --strict -o tests/annotations_new.pyi`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a134b450908329a19006f30f9c3638