### PR TITLE
Fix nested class qualification in emitted stubs

### DIFF
--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -1085,3 +1085,13 @@ def _wrap(fn):
 
 @_wrap
 def wrapped_callable(x: int, y: str) -> str: ...
+
+
+# Nested class annotation should be fully qualified
+class NestedOuter:
+    class Inner:
+        pass
+
+
+def nested_class_annotation(x: NestedOuter.Inner) -> NestedOuter.Inner:
+    return x

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -607,6 +607,11 @@ class OverrideEarly(Basic):
 
 def wrapped_callable(x: int, y: str) -> str: ...
 
+class NestedOuter:
+    class Inner: ...
+
+def nested_class_annotation(x: NestedOuter.Inner) -> NestedOuter.Inner: ...
+
 LITERAL_STR_VAR: LiteralString
 
 DICT_WITH_IMPLICIT_ANY: dict[int]  # type: ignore[type-arg]  # pyright: ignore[reportInvalidTypeArguments]


### PR DESCRIPTION
## Summary
- avoid leaking enum internals when qualifying class names
- recursively map nested classes so annotations refer to proper nested paths

## Testing
- `ruff format`
- `ruff check --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a14c03c3588329b3f9d13892f5f13c