### PR TITLE
Ensure importlib.util is imported in stub generator

### DIFF
--- a/macrotype/stubgen.py
+++ b/macrotype/stubgen.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import importlib
+import importlib.util
 import shutil
 import subprocess
 import sys

--- a/tests/test_load_module_from_path.py
+++ b/tests/test_load_module_from_path.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+
+
+def test_load_module_from_path_importlib_util(tmp_path):
+    sys.modules.pop("importlib.util", None)
+    if hasattr(importlib, "util"):
+        delattr(importlib, "util")
+    sys.modules.pop("macrotype.stubgen", None)
+
+    import macrotype.stubgen as stubgen
+
+    p = tmp_path / "m.py"
+    p.write_text("x = 1\n")
+    mod = stubgen.load_module_from_path(p)
+    assert mod.x == 1


### PR DESCRIPTION
## Summary
- import `importlib.util` directly so `load_module_from_path` works even when `importlib.util` wasn't previously loaded
- add regression test confirming `load_module_from_path` imports `importlib.util`

## Testing
- `ruff format macrotype/stubgen.py tests/test_load_module_from_path.py`
- `ruff check macrotype/stubgen.py tests/test_load_module_from_path.py --fix`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a156dbd25c8329a2d219a9b308b8df