### PR TITLE
Preserve package structure when generating stubs

### DIFF
--- a/__macrotype__/macrotype/stubgen.pyi
+++ b/__macrotype__/macrotype/stubgen.pyi
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ast import If, NodeTransformer, expr, stmt
 from pathlib import Path
+from types import ModuleType
 
 annotations = annotations
 

--- a/macrotype/cli/__main__.py
+++ b/macrotype/cli/__main__.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 from .. import stubgen
-from . import DEFAULT_OUT_DIR, _default_output_path
+from . import _default_output_path
 from .watch import watch_and_run
 
 
@@ -86,10 +86,6 @@ def _stub_main(argv: list[str]) -> int:
             else:
                 dest = Path(args.output) if args.output else default_output
                 overlay = stub_overlay_dir
-                if overlay is None and dest.parent != path.parent:
-                    overlay = (
-                        DEFAULT_OUT_DIR if dest.is_relative_to(DEFAULT_OUT_DIR) else dest.parent
-                    )
                 stubgen.process_file(
                     path,
                     dest,
@@ -106,10 +102,6 @@ def _stub_main(argv: list[str]) -> int:
             else:
                 out_dir = Path(args.output) if args.output else default_output
                 overlay = stub_overlay_dir
-                if overlay is None and out_dir and out_dir != path:
-                    overlay = (
-                        DEFAULT_OUT_DIR if out_dir.is_relative_to(DEFAULT_OUT_DIR) else out_dir
-                    )
             stubgen.process_directory(
                 path,
                 out_dir,

--- a/macrotype/stubgen.py
+++ b/macrotype/stubgen.py
@@ -268,7 +268,11 @@ def process_directory(
 ) -> list[Path]:
     outputs = []
     for src in iter_python_files(directory):
-        dest = (out_dir / src.with_suffix(".pyi").name) if out_dir else None
+        if out_dir:
+            rel = src.relative_to(directory).with_suffix(".pyi")
+            dest = out_dir / rel
+        else:
+            dest = None
         try:
             outputs.append(
                 process_file(

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -97,9 +97,24 @@ def test_process_directory_skips_dunder_main(tmp_path) -> None:
 
     out = tmp_path / "out"
     process_directory(pkg, out)
-    names = {p.name for p in out.iterdir()}
+    names = {p.name for p in (out / "sub").iterdir()}
     assert "mod.pyi" in names
     assert "__main__.pyi" not in names
+
+
+def test_process_directory_preserves_structure(tmp_path) -> None:
+    pkg = tmp_path / "pkg"
+    (pkg / "a").mkdir(parents=True)
+    (pkg / "a" / "__init__.py").write_text("")
+    (pkg / "a" / "mod.py").write_text("A = 1\n")
+    (pkg / "b").mkdir(parents=True)
+    (pkg / "b" / "__init__.py").write_text("")
+    (pkg / "b" / "mod.py").write_text("B = 2\n")
+
+    out = tmp_path / "out"
+    process_directory(pkg, out)
+    assert (out / "a" / "mod.pyi").exists()
+    assert (out / "b" / "mod.pyi").exists()
 
 
 def test_module_alias(tmp_path) -> None:

--- a/tests/test_stub_dir.py
+++ b/tests/test_stub_dir.py
@@ -31,4 +31,7 @@ def test_cli_stub_overlay_dir(tmp_path, overlay_subdir):
     if overlay_subdir:
         args.extend(["--stub-overlay-dir", str(stub_dir)])
     subprocess.run(args, check=True, cwd=repo_root)
-    _check_overlay(stub_dir, dest)
+    if overlay_subdir:
+        _check_overlay(stub_dir, dest)
+    else:
+        assert not (stub_dir / "tests" / "annotations_new.pyi").exists()


### PR DESCRIPTION
## Summary
- write stubs into directories mirroring the source package layout
- stop defaulting to stub overlays in the CLI
- test nested stub output and overlay option

## Testing
- `ruff format macrotype/stubgen.py macrotype/cli/__main__.py tests/test_stub_dir.py tests/test_all.py`
- `ruff check --fix macrotype/stubgen.py macrotype/cli/__main__.py tests/test_stub_dir.py tests/test_all.py`
- `ruff format __macrotype__/macrotype/stubgen.pyi`
- `ruff check --fix __macrotype__/macrotype/stubgen.pyi`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a39af35b608329ac3eec984b5283ab