### PR TITLE
Refactor stubgen to operate on modules

### DIFF
--- a/__macrotype__/macrotype/stubgen.pyi
+++ b/__macrotype__/macrotype/stubgen.pyi
@@ -1,42 +1,38 @@
-# Generated via: manual edit
+# Generated via: macrotype macrotype/stubgen.py -o __macrotype__/macrotype/stubgen.pyi
 # Do not edit by hand
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from types import ModuleType
-from typing import Sequence
 
 from macrotype.modules.ir import SourceInfo
 
-def _header_lines(command: str | None) -> list[str]: ...
+annotations = annotations
+
+def _header_lines(command: None | str) -> list[str]: ...
 def _has_type_checking_guard(code: str) -> bool: ...
 def _module_name_from_path(path: Path) -> str: ...
-def load_module(name: str, *, allow_type_checking: bool = ...) -> ModuleType: ...
-def load_module_from_code(
-    code: str, name: str = ..., *, allow_type_checking: bool = ...
-) -> ModuleType: ...
-def stub_lines(
+def load_module(name: str, allow_type_checking: bool) -> ModuleType: ...
+def load_module_from_code(code: str, name: str, allow_type_checking: bool) -> ModuleType: ...
+def stub_lines(module: ModuleType, source_info: None | SourceInfo, strict: bool) -> list[str]: ...
+def write_stub(dest: Path, lines: list[str], command: None | str) -> None: ...
+def process_module(
     module: ModuleType,
-    *,
-    source_info: SourceInfo | None = ...,
-    strict: bool = ...,
-) -> list[str]: ...
-def write_stub(dest: Path, lines: list[str], command: str | None = ...) -> None: ...
-def iter_python_files(target: Path, *, skip: Sequence[str] = ...) -> list[Path]: ...
+    dest: None | Path,
+    command: None | str,
+    strict: bool,
+    source_info: None | SourceInfo,
+) -> Path: ...
+def iter_python_files(target: Path, skip: Sequence[str]) -> list[Path]: ...
 def process_file(
-    src: Path,
-    dest: Path | None = ...,
-    *,
-    command: str | None = ...,
-    strict: bool = ...,
-    allow_type_checking: bool = ...,
+    src: Path, dest: None | Path, command: None | str, strict: bool, allow_type_checking: bool
 ) -> Path: ...
 def process_directory(
     directory: Path,
-    out_dir: Path | None = ...,
-    *,
-    command: str | None = ...,
-    strict: bool = ...,
-    allow_type_checking: bool = ...,
-    skip: Sequence[str] = ...,
+    out_dir: None | Path,
+    command: None | str,
+    strict: bool,
+    allow_type_checking: bool,
+    skip: Sequence[str],
 ) -> list[Path]: ...

--- a/tests/modules/test_ir.py
+++ b/tests/modules/test_ir.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import sys
 import types
 import typing
 
@@ -242,5 +243,8 @@ def test_strict_mode_normalizes_union() -> None:
 
 def test_strict_mode_raises_on_invalid_annotation() -> None:
     mod = importlib.reload(importlib.import_module("tests.strict_error"))
-    with pytest.raises(TypeError):
-        from_module(mod, strict=True)
+    try:
+        with pytest.raises(TypeError):
+            from_module(mod, strict=True)
+    finally:
+        sys.modules.pop("tests.strict_error", None)

--- a/tests/modules/test_source_info.py
+++ b/tests/modules/test_source_info.py
@@ -11,13 +11,14 @@ from macrotype.stubgen import load_module
 
 def test_source_info_attached(tmp_path: Path) -> None:
     code = """# header1\n# header2\nX = 1\n"""
-    path = tmp_path / "mod.py"
+    path = tmp_path / "source_info_mod.py"
     path.write_text(code)
     sys.path.insert(0, str(tmp_path))
     try:
-        mod = load_module("mod")
+        mod = load_module("source_info_mod")
     finally:
         sys.path.remove(str(tmp_path))
+        sys.modules.pop("source_info_mod", None)
     header, comments, line_map = extract_source_info(code)
     info = SourceInfo(headers=header, comments=comments, line_map=line_map)
     mi = from_module(mod, source_info=info)
@@ -25,4 +26,3 @@ def test_source_info_attached(tmp_path: Path) -> None:
     assert mi.source.headers == ["# header1", "# header2"]
     assert mi.source.comments[1] == "# header1"
     assert mi.source.line_map["X"] == 3
-    getattr(mod, "__cleanup__")()

--- a/tests/test_invalid_typing.py
+++ b/tests/test_invalid_typing.py
@@ -19,7 +19,7 @@ def test_invalid_literal_error():
     msg = str(exc.value)
     assert "Illegal Literal value" in msg
     assert "Literal" in msg
-    getattr(mod, "__cleanup__")()
+    sys.modules.pop("tests.annotations_invalid", None)
 
 
 def test_invalid_non_type_error():
@@ -29,40 +29,40 @@ def test_invalid_non_type_error():
     info = SourceInfo(headers=header, comments=comments, line_map=line_map)
     lines = stub_lines(mod, source_info=info, strict=True)
     assert lines[-1] == "BAD_NON_TYPE: 123"
-    getattr(mod, "__cleanup__")()
+    sys.modules.pop("tests.annotations_invalid_non_type", None)
 
 
 def test_unresolved_string_kept_as_name(tmp_path):
     code = 'X: "Missing"\n'
-    path = tmp_path / "mod.py"
+    path = tmp_path / "unresolved_mod.py"
     path.write_text(code)
     sys.path.insert(0, str(tmp_path))
     try:
-        mod = load_module("mod")
+        mod = load_module("unresolved_mod")
     finally:
         sys.path.remove(str(tmp_path))
+        sys.modules.pop("unresolved_mod", None)
     header, comments, line_map = extract_source_info(code)
     info = SourceInfo(headers=header, comments=comments, line_map=line_map)
     lines = stub_lines(mod, source_info=info, strict=True)
     assert lines == ["X: Missing"]
-    getattr(mod, "__cleanup__")()
 
 
 def test_forward_ref_kept_as_name(tmp_path):
     code = 'import typing\nX: typing.ForwardRef("Missing")\n'
-    path = tmp_path / "mod.py"
+    path = tmp_path / "forward_ref_mod.py"
     path.write_text(code)
     sys.path.insert(0, str(tmp_path))
     try:
-        mod = load_module("mod")
+        mod = load_module("forward_ref_mod")
     finally:
         sys.path.remove(str(tmp_path))
+        sys.modules.pop("forward_ref_mod", None)
     header, comments, line_map = extract_source_info(code)
     info = SourceInfo(headers=header, comments=comments, line_map=line_map)
     lines = stub_lines(mod, source_info=info, strict=True)
     assert lines[0] == "from typing import Missing"
     assert lines[-1] == "X: Missing"
-    getattr(mod, "__cleanup__")()
 
 
 def test_misplaced_ellipsis_in_tuple_raises_error() -> None:
@@ -75,4 +75,4 @@ def test_misplaced_ellipsis_in_tuple_raises_error() -> None:
     msg = str(exc.value)
     assert "Ellipsis" in msg
     assert "final argument" in msg
-    getattr(mod, "__cleanup__")()
+    sys.modules.pop("tests.strict_error", None)

--- a/tests/test_process_module.py
+++ b/tests/test_process_module.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+from macrotype.stubgen import load_module, process_module
+
+
+def test_process_module_defaults_to_module_file(tmp_path: Path) -> None:
+    pkg = tmp_path / "process_pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("VALUE = 1\n")
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        mod = load_module("process_pkg")
+        out = process_module(mod)
+        assert out == pkg / "__init__.pyi"
+        assert "VALUE: int" in out.read_text()
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("process_pkg", None)


### PR DESCRIPTION
## Summary
- drop sys.modules cleanup from `load_module`
- add `process_module` entrypoint that writes stubs from a module object
- update tests for new module-centric behavior

## Testing
- `ruff format macrotype/stubgen.py tests/test_load_module_cleanup.py tests/test_process_module.py __macrotype__/macrotype/stubgen.pyi`
- `ruff check --fix macrotype/stubgen.py __macrotype__/macrotype/stubgen.pyi`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a40e15bf2083298b316f277c08da4b