### PR TITLE
Avoid scanning foreign members

### DIFF
--- a/__macrotype__/macrotype/modules/scanner.pyi
+++ b/__macrotype__/macrotype/modules/scanner.pyi
@@ -1,7 +1,8 @@
-# Generated via: macrotype macrotype
+# Generated via: macrotype macrotype/modules/scanner.py -o __macrotype__/macrotype/modules/scanner.pyi
 # Do not edit by hand
 from __future__ import annotations
 
+from types import ModuleType
 from typing import Any, Callable
 
 from macrotype.modules.ir import ClassDecl, FuncDecl, ModuleDecl


### PR DESCRIPTION
## Summary
- stop scanning class members defined in other modules
- regenerate scanner stub

## Testing
- `ruff check --fix macrotype/modules/scanner.py __macrotype__/macrotype/modules/scanner.pyi`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4147224108329b2bc891477be6884