### PR TITLE
Handle builtins with unknown signatures

### DIFF
--- a/macrotype/modules/scanner.py
+++ b/macrotype/modules/scanner.py
@@ -142,12 +142,14 @@ def _scan_function(fn: t.Callable) -> FuncDecl:
                 ann = _eval_annotation(ann, fn.__globals__)
             params.append(Site(role="param", name=p.name, annotation=ann))
     except (TypeError, ValueError):
-        pass
+        params.append(Site(role="param", name="...", annotation=inspect._empty))
 
     ret = None
     if "return" in raw_ann:
         ann = _eval_annotation(raw_ann["return"], fn.__globals__)
         ret = Site(role="return", annotation=ann)
+    elif params and params[0].name == "...":
+        ret = Site(role="return", annotation=t.Any)
 
     decos: list[str] = []
     if getattr(fn, "__isabstractmethod__", False):

--- a/tests/modules/test_ir.py
+++ b/tests/modules/test_ir.py
@@ -4,6 +4,7 @@ import importlib
 import sys
 import types
 import typing
+from typing import Any
 
 import pytest
 
@@ -16,7 +17,7 @@ from macrotype.modules.ir import (
     TypeDefDecl,
     VarDecl,
 )
-from macrotype.modules.scanner import scan_module
+from macrotype.modules.scanner import _scan_function, scan_module
 from macrotype.modules.transformers import canonicalize_foreign_symbols, expand_overloads
 
 
@@ -117,6 +118,13 @@ def test_properties_detected_as_functions_or_vars(idx: dict[str, object]) -> Non
     assert isinstance(w, ClassDecl)
     members = {m.name for m in w.members}
     assert {"wrapped_prop", "wrapped_static", "wrapped_cls"} <= members
+
+
+def test_builtin_function_signature() -> None:
+    decl = _scan_function(bytes)
+    assert isinstance(decl, FuncDecl)
+    assert [p.name for p in decl.params] == ["..."]
+    assert decl.ret and decl.ret.annotation is Any
 
 
 def test_variadic_things_dont_crash(idx: dict[str, object]) -> None:


### PR DESCRIPTION
## Summary
- handle builtin callables that lack inspect signatures by emitting an ellipsis parameter list
- default return annotation to `Any` when a signature cannot be inspected
- test scanning of the builtin `bytes` constructor

## Testing
- `ruff format macrotype/modules/scanner.py tests/modules/test_ir.py`
- `ruff check --fix macrotype/modules/scanner.py tests/modules/test_ir.py`
- `pytest tests/modules/test_ir.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4911834b88329903ad7a31f6e0e00