### PR TITLE
Avoid typing import for local forward references

### DIFF
--- a/macrotype/modules/transformers/resolve_imports.py
+++ b/macrotype/modules/transformers/resolve_imports.py
@@ -39,13 +39,18 @@ def resolve_imports(mi: ModuleDecl) -> None:
         if (
             (
                 getattr(a, "__module__", None) == "typing"
-                and not isinstance(a, (t.TypeVar, t.ParamSpec, t.TypeVarTuple))
+                and not isinstance(a, (t.TypeVar, t.ParamSpec, t.TypeVarTuple, t.ForwardRef))
                 and a is not t.Union
             )
             or a is Callable
             or a is ABC_Callable
         )
     }
+    for a in atoms.values():
+        if isinstance(a, t.ForwardRef):
+            name = name_map[id(a)]
+            if name not in context:
+                typing_names.add(name)
     typing_names.update(_collect_typing_names(mi.members))
 
     external: dict[str, set[str]] = defaultdict(set)

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -406,6 +406,14 @@ class EmployeeModel(SQLBase):
     manager_id: Mapped[ManagerModel.id_type]
 
 
+# Forward reference to a local class should not generate typing imports
+class ForwardRefModel: ...
+
+
+class UsesForwardRef:
+    items: list["ForwardRefModel"]
+
+
 # Basic callable examples
 def sum_of(*args: tuple[int]) -> int:
     return sum(args)

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -10,8 +10,33 @@ from math import sin
 from operator import attrgetter
 from pathlib import Path
 from re import Pattern
-
-from typing import Annotated, Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, final, overload, override, runtime_checkable
+from typing import (
+    Annotated,
+    Any,
+    Callable,
+    ClassVar,
+    Concatenate,
+    Final,
+    Literal,
+    LiteralString,
+    NamedTuple,
+    Never,
+    NewType,
+    NotRequired,
+    ParamSpec,
+    Protocol,
+    Required,
+    Self,
+    TypedDict,
+    TypeGuard,
+    TypeVar,
+    TypeVarTuple,
+    Unpack,
+    final,
+    overload,
+    override,
+    runtime_checkable,
+)
 
 P = ParamSpec("P")
 
@@ -84,8 +109,7 @@ class InheritedFinal:
     base: Final[int]
     sub: Final[str]
 
-class Undefined:
-    ...
+class Undefined: ...
 
 class UndefinedCls:
     a: int
@@ -100,21 +124,13 @@ class RequiredUndefinedCls:
     b: str
 
 def pos_only_func(a: int, b: str) -> None: ...
-
 def kw_only_func(x: int, y: str) -> None: ...
-
 def pos_and_kw(a: int, b: int, c: int) -> None: ...
-
 def iter_sequence(seq: Sequence[int]) -> Iterator[int]: ...
-
 def simple_wrap(fn: Callable[[int], int]) -> Callable[[int], int]: ...
-
 def double_wrapped(x: int) -> int: ...
-
 def cached_add(a: int, b: int) -> int: ...
-
-def annotated_fn(x: Annotated[int, 'inp']) -> Annotated[str, 'out']: ...
-
+def annotated_fn(x: Annotated[int, "inp"]) -> Annotated[str, "out"]: ...
 def wrap_descriptor(desc): ...
 
 class WrappedDescriptors:
@@ -128,9 +144,7 @@ class WrappedDescriptors:
     def wrapped_cached(self) -> int: ...
 
 def make_emitter(name: str): ...
-
 def emitted_a(x: int) -> int: ...
-
 def make_emitter_cls(name: str): ...
 
 class EmittedCls:
@@ -138,25 +152,20 @@ class EmittedCls:
 
 def make_dynamic_cls(): ...
 
-class FixedModuleCls:
-    ...
+class FixedModuleCls: ...
 
 class EmittedMap:
     @overload
-    def __getitem__(self, key: Literal['a']) -> Literal[1]: ...
+    def __getitem__(self, key: Literal["a"]) -> Literal[1]: ...
     @overload
-    def __getitem__(self, key: Literal['b']) -> Literal[2]: ...
+    def __getitem__(self, key: Literal["b"]) -> Literal[2]: ...
 
 def path_passthrough(p: Path) -> Path: ...
-
 @overload
 def loop_over(x: bytearray) -> str: ...
-
 @overload
 def loop_over(x: bytes) -> str: ...
-
 def identity[T](x: T) -> T: ...
-
 def as_tuple[*Ts](*args: Unpack[Ts]) -> tuple[Unpack[Ts]]: ...
 
 class Variadic[*Ts]:
@@ -165,43 +174,30 @@ class Variadic[*Ts]:
 
 @overload
 def times_two(val: Literal[3], factor: Literal[2]) -> Literal[6]: ...
-
 @overload
 def times_two(val: int, factor: int) -> int: ...
-
 @overload
 def bool_gate(flag: Literal[True]) -> Literal[1]: ...
-
 @overload
 def bool_gate(flag: Literal[False]) -> Literal[0]: ...
-
 @overload
 def bool_gate(flag: bool) -> int: ...
-
 @overload
 def nan_case(x: float) -> float: ...
-
 @overload
 def nan_case(x: float | str) -> float: ...
-
 @overload
 def float_case(x: float) -> float: ...
-
 @overload
 def float_case(x: float | str) -> float: ...
-
 @overload
-def bytes_case(x: Literal[b'x']) -> Literal[b'x']: ...
-
+def bytes_case(x: Literal[b"x"]) -> Literal[b"x"]: ...
 @overload
 def bytes_case(x: bytes) -> bytes: ...
-
 @overload
 def mixed_overload(x: str) -> str: ...
-
 @overload
 def mixed_overload(x: Literal[0]) -> Literal[0]: ...
-
 @overload
 def mixed_overload(x: int | str) -> int | str: ...
 
@@ -212,8 +208,7 @@ class AbstractBase(ABC):
 class BadParams:
     value: int
 
-class Mapped[T]:
-    ...
+class Mapped[T]: ...
 
 class SQLBase:
     @classmethod
@@ -232,14 +227,15 @@ class EmployeeModel(SQLBase):
     id: Mapped[EmployeeModelId]
     id_type = NewType("id_type", int)
 
+class ForwardRefModel: ...
+
+class UsesForwardRef:
+    items: list[ForwardRefModel]
+
 def sum_of(*args: tuple[int]) -> int: ...
-
 def dict_echo[*Ts](**kwargs: dict[str, Any]) -> dict[str, Any]: ...
-
 def use_params[**P](func: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
-
 def is_str_list(val: list[object]) -> TypeGuard[list[str]]: ...
-
 def is_int(val: object) -> TypeGuard[int]: ...
 
 PLAIN_FINAL_VAR: Final[int]
@@ -267,25 +263,18 @@ def echo_literal(value: LiteralString) -> LiteralString: ...
 NONE_VAR: None
 
 async def async_add_one(x: int) -> int: ...
-
 async def gen_range[*Ts](n: int) -> AsyncIterator[int]: ...
-
 @final
-class FinalClass:
-    ...
+class FinalClass: ...
 
 class HasFinalMethod:
     @final
     def do_final(self) -> None: ...
 
 def final_func(x: int) -> int: ...
-
 def pragma_func(x: int) -> int: ...  # pyright: ignore
-
 def do_nothing() -> None: ...
-
 def always_raises() -> Never: ...
-
 def never_returns() -> Never: ...
 
 class SelfExample:
@@ -304,8 +293,7 @@ class Runnable(Protocol):
 class LaterRunnable(Protocol):
     def run(self) -> int: ...
 
-class NoProtoMethods(Protocol):
-    ...
+class NoProtoMethods(Protocol): ...
 
 class Info(TypedDict):
     name: str
@@ -360,10 +348,8 @@ class HasPartialMethod:
 
 @overload
 def over(x: int) -> int: ...
-
 @overload
 def over(x: str) -> str: ...
-
 @dataclass
 class Point:
     x: int
@@ -439,8 +425,8 @@ class Permission(IntFlag):
     EXECUTE = 4
 
 class StrEnum(str, Enum):
-    A = 'a'
-    B = 'b'
+    A = "a"
+    B = "b"
 
 class PointEnum(Enum):
     INLINE = Point
@@ -448,40 +434,35 @@ class PointEnum(Enum):
 
 def use_tuple(tp: tuple[int, ...]) -> tuple[int, ...]: ...
 
-class UserBox[T]:
-    ...
+class UserBox[T]: ...
 
-NESTED_ANNOTATED: Annotated[int, 'a', 'b']
+NESTED_ANNOTATED: Annotated[int, "a", "b"]
 
-TRIPLE_ANNOTATED: Annotated[int, 'x', 'y', 'z']
+TRIPLE_ANNOTATED: Annotated[int, "x", "y", "z"]
 
-ANNOTATED_OPTIONAL_META: Annotated[None | int, 'meta']
+ANNOTATED_OPTIONAL_META: Annotated[None | int, "meta"]
 
-ANNOTATED_FINAL_META: Final[Annotated[int, 'meta']]
+ANNOTATED_FINAL_META: Final[Annotated[int, "meta"]]
 
-ANNOTATED_WRAP_GENERIC: Annotated[list[Annotated[int, 'inner']], 'outer']
+ANNOTATED_WRAP_GENERIC: Annotated[list[Annotated[int, "inner"]], "outer"]
 
 class MetaRepr:
     def __repr__(self) -> str: ...  # pragma: no cover - simple repr
 
 ANNOTATED_OBJ_META: Annotated[int, MetaRepr()]
 
-def with_paramspec_args_kwargs[**P](fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs) -> int: ...
-
+def with_paramspec_args_kwargs[**P](
+    fn: Callable[P, int], *args: P.args, **kwargs: P.kwargs
+) -> int: ...
 def prepend_one[**P](fn: Callable[Concatenate[int, P], int]) -> Callable[P, int]: ...
-
 @overload
 def special_neg(val: Literal[0]) -> Literal[0]: ...
-
 @overload
 def special_neg(val: Literal[1]) -> Literal[-1]: ...
-
 @overload
 def special_neg(val: int) -> int: ...
-
 @overload
 def parse_int_or_none(val: None) -> None: ...
-
 @overload
 def parse_int_or_none(val: None | str) -> None | int: ...
 
@@ -499,7 +480,7 @@ Other = dict[str, int]
 
 ListIntGA = list[int]
 
-ForwardAlias = 'FutureClass'  # noqa: F821
+ForwardAlias = "FutureClass"  # noqa: F821
 
 CallableP = Callable[P, int]
 
@@ -529,14 +510,13 @@ ANNOTATED_FINAL: Final[int]
 
 ANNOTATED_CLASSVAR: int
 
-LITERAL_STR_QUOTED: Literal['hi']
+LITERAL_STR_QUOTED: Literal["hi"]
 
 BOX_SIZE: Final[int]
 
 BORDER_SIZE: Final[int]
 
-class FutureClass:
-    ...
+class FutureClass: ...
 
 UNANNOTATED_CONST: int
 
@@ -552,8 +532,7 @@ NONE_ALIAS: Any
 
 def takes_none_alias(x: None) -> None: ...
 
-class CustomInt(int):
-    ...
+class CustomInt(int): ...
 
 UNANNOTATED_CUSTOM_INT: CustomInt
 
@@ -566,11 +545,8 @@ SITE_PROV_VAR: int
 COMMENTED_VAR: int  # pragma: var
 
 def mult(a, b: int): ...
-
 def takes_optional(x): ...
-
 def takes_none_param(x: None) -> None: ...
-
 def _alias_target() -> None: ...
 
 PRIMARY_ALIAS = _alias_target
@@ -578,16 +554,12 @@ PRIMARY_ALIAS = _alias_target
 SECONDARY_ALIAS = _alias_target
 
 def _wrap(fn): ...
-
 def wrapped_with_default(x: int, y: int) -> int: ...
-
 def commented_func(x: int) -> None: ...  # pragma: func
-
 def UNTYPED_LAMBDA(x, y): ...  # noqa: F821
-
 def TYPED_LAMBDA(a, b): ...
 
-ANNOTATED_EXTRA: Annotated[str, 'extra']
+ANNOTATED_EXTRA: Annotated[str, "extra"]
 
 class Basic:
     simple: list[str]
@@ -596,13 +568,13 @@ class Basic:
     union: int | str  # typing.Union should remain unaltered
     pipe_union: int | str
     func: Callable[[int, str], bool]
-    annotated: Annotated[int, 'meta']
+    annotated: Annotated[int, "meta"]
     pattern: Pattern[str]
     uid: UserId
-    lit_attr: Literal['a', 'b']
+    lit_attr: Literal["a", "b"]
     def copy[T](self, param: T) -> T: ...
     def curry[**P](self, f: Callable[P, int]) -> Callable[P, int]: ...
-    def literal_method(self, flag: Literal['on', 'off']) -> Literal[1, 0]: ...
+    def literal_method(self, flag: Literal["on", "off"]) -> Literal[1, 0]: ...
     @classmethod
     def cls_method(cls, value: int) -> Basic: ...
     @classmethod
@@ -624,11 +596,11 @@ class Basic:
     class Nested:
         x: float
         y: str
+
     @cached_property
     def cached(self) -> int: ...
 
-class Child(Basic):
-    ...
+class Child(Basic): ...
 
 class OverrideChild(Basic):
     @override
@@ -653,8 +625,7 @@ class OverrideEarly(Basic):
 def wrapped_callable(x: int, y: str) -> str: ...
 
 class NestedOuter:
-    class Inner:
-        ...
+    class Inner: ...
 
 def nested_class_annotation(x: NestedOuter.Inner) -> NestedOuter.Inner: ...
 
@@ -662,26 +633,10 @@ class PointNT(NamedTuple):
     x: int
     y: int
 
-class Unrelated:
-    ...
-
-class BaseModel:
-    ...
-
-class StdModel(BaseModel):
-    ...
-
-class Repeater(StdModel):
-    ...
-
-class TopBase:
-    ...
-
-class MidBase(TopBase):
-    ...
-
-class BotBase(MidBase):
-    ...
+class Unrelated: ...
+class BaseModel: ...
+class StdModel(BaseModel): ...
+class Repeater(StdModel): ...
 
 class OverloadedClassMethod:
     @classmethod
@@ -690,6 +645,10 @@ class OverloadedClassMethod:
     @classmethod
     @overload
     def get_by_id(cls, model_id: int) -> Self: ...
+
+class TopBase: ...
+class MidBase(TopBase): ...
+class BotBase(MidBase): ...
 
 LITERAL_STR_VAR: LiteralString
 


### PR DESCRIPTION
## Summary
- ensure `resolve_imports` ignores forward references that point to local names
- add regression test for forward reference imports

## Testing
- `python -m macrotype tests/annotations_new.py --strict -o tests/annotations_new.pyi`
- `ruff format macrotype/modules/transformers/resolve_imports.py tests/annotations_new.py tests/annotations_new.pyi`
- `ruff check --fix macrotype/modules/transformers/resolve_imports.py tests/annotations_new.py tests/annotations_new.pyi`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4df9beb648329a5afef85bb6a7ae5