### PR TITLE
Fix nested class import resolution

### DIFF
--- a/macrotype/modules/transformers/resolve_imports.py
+++ b/macrotype/modules/transformers/resolve_imports.py
@@ -68,7 +68,8 @@ def resolve_imports(mi: ModuleDecl) -> None:
             continue
         if modname == "types" and name == "UnionType":
             continue
-        external[modname].add(name)
+        base_name = name.split(".", 1)[0]
+        external[modname].add(base_name)
 
     mi.imports = ImportBlock(typing=typing_names, froms=dict(external))
 

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -54,6 +54,7 @@ from macrotype.meta_types import (
     overload_for,
     set_module,
 )
+from tests.external_nested import ExternalOuter
 
 P = ParamSpec("P")
 
@@ -1121,6 +1122,13 @@ class NestedOuter:
 
 
 def nested_class_annotation(x: NestedOuter.Inner) -> NestedOuter.Inner:
+    return x
+
+
+# Nested class from external module should import base name only
+def external_nested_class_annotation(
+    x: ExternalOuter.Inner,
+) -> ExternalOuter.Inner:
     return x
 
 

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -10,6 +10,7 @@ from math import sin
 from operator import attrgetter
 from pathlib import Path
 from re import Pattern
+from tests.external_nested import ExternalOuter
 
 from typing import Annotated, Any, Callable, ClassVar, Concatenate, Final, Literal, LiteralString, NamedTuple, Never, NewType, NotRequired, ParamSpec, Protocol, Required, Self, TypeGuard, TypeVar, TypeVarTuple, TypedDict, Unpack, dataclass_transform, final, overload, override, runtime_checkable
 
@@ -663,6 +664,8 @@ class NestedOuter:
         ...
 
 def nested_class_annotation(x: NestedOuter.Inner) -> NestedOuter.Inner: ...
+
+def external_nested_class_annotation(x: ExternalOuter.Inner) -> ExternalOuter.Inner: ...
 
 class PointNT(NamedTuple):
     x: int

--- a/tests/external_nested.py
+++ b/tests/external_nested.py
@@ -1,0 +1,3 @@
+class ExternalOuter:
+    class Inner:
+        pass


### PR DESCRIPTION
## Summary
- avoid importing nested class paths like `CompositeProperty.Comparator`
- cover import base-name logic with new test

## Testing
- `ruff format`
- `ruff check --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a50b9736588329810227bc116a28fb