### PR TITLE
Handle simple TYPE_CHECKING import blocks

### DIFF
--- a/__macrotype__/macrotype/modules/ir.pyi
+++ b/__macrotype__/macrotype/modules/ir.pyi
@@ -1,12 +1,10 @@
-# Generated via: macrotype macrotype
+# Generated via: macrotype macrotype/modules/ir.py -o __macrotype__/macrotype/modules/ir.pyi
 # Do not edit by hand
 from __future__ import annotations
-
 from collections.abc import Iterator
-from dataclasses import dataclass
-from typing import Decl, Literal
+from dataclasses import dataclass, field
 
-annotations = annotations
+from typing import Literal
 
 @dataclass(kw_only=True)
 class Decl:
@@ -14,13 +12,13 @@ class Decl:
     obj: EllipsisType | None | object
     comment: None | str
     emit: bool
-    def get_children(self) -> tuple["Decl", ...]: ...
+    def get_children(self) -> tuple['Decl', ...]: ...
     def get_annotation_sites(self) -> tuple[Site, ...]: ...
     def walk(self) -> Iterator[Decl]: ...
 
 @dataclass(kw_only=True)
 class Site:
-    role: Literal["var", "return", "param", "base", "alias_value", "td_field"]
+    role: Literal['var', 'return', 'param', 'base', 'alias_value', 'td_field']
     name: None | str
     index: None | int
     annotation: object
@@ -71,6 +69,7 @@ class SourceInfo:
     headers: list[str]
     comments: dict[int, str]
     line_map: dict[str, int]
+    tc_imports: dict[str, set[str]]
 
 @dataclass(kw_only=True)
 class ImportBlock:

--- a/__macrotype__/macrotype/modules/source.pyi
+++ b/__macrotype__/macrotype/modules/source.pyi
@@ -1,11 +1,16 @@
-# Generated via: macrotype macrotype
+# Generated via: macrotype macrotype/modules/source.py -o __macrotype__/macrotype/modules/source.pyi
 # Do not edit by hand
 from __future__ import annotations
+from ast import AST
+from collections import defaultdict
+from re import Pattern
 
-from re import PRAGMA_PREFIX
+PRAGMA_PREFIX = Pattern
 
-annotations = annotations
+def _mentions_type_checking(expr: AST) -> bool: ...
 
-PRAGMA_PREFIX = PRAGMA_PREFIX
+def _tc_imports_from_tree(tree: AST, allow_complex: bool) -> dict[str, set[str]]: ...
 
-def extract_source_info(code: str) -> tuple[list[str], dict[int, str], dict[str, int]]: ...
+def extract_type_checking_imports(code: str, allow_type_checking: bool) -> dict[str, set[str]]: ...
+
+def extract_source_info(code: str, allow_type_checking: bool) -> tuple[list[str], dict[int, str], dict[str, int], dict[str, set[str]]]: ...

--- a/__macrotype__/macrotype/modules/transformers/resolve_imports.pyi
+++ b/__macrotype__/macrotype/modules/transformers/resolve_imports.pyi
@@ -1,14 +1,13 @@
-# Generated via: macrotype macrotype
+# Generated via: macrotype macrotype/modules/transformers/resolve_imports.py --strict -o __macrotype__/macrotype/modules/transformers/resolve_imports.pyi
 # Do not edit by hand
 from __future__ import annotations
-
+from collections import defaultdict
 from collections.abc import Iterable
-
-from macrotype.modules.ir import Decl, ModuleDecl
-
-annotations = annotations
+from macrotype.modules.emit import build_name_map, collect_all_annotations, flatten_annotation_atoms
+from macrotype.modules.ir import ClassDecl, Decl, ImportBlock, ModuleDecl, TypeDefDecl
 
 _MODULE_ALIASES: dict[str, str]
 
 def resolve_imports(mi: ModuleDecl) -> None: ...
+
 def _collect_typing_names(symbols: Iterable[Decl]) -> set[str]: ...

--- a/__macrotype__/macrotype/modules/transformers/source_info.pyi
+++ b/__macrotype__/macrotype/modules/transformers/source_info.pyi
@@ -1,7 +1,6 @@
-# Generated via: manual edit
+# Generated via: macrotype macrotype/modules/transformers/source_info.py --strict -o __macrotype__/macrotype/modules/transformers/source_info.pyi
 # Do not edit by hand
 from __future__ import annotations
-
 from macrotype.modules.ir import ModuleDecl, SourceInfo
 
-def add_source_info(mi: ModuleDecl, source_info: SourceInfo | None = ...) -> None: ...
+def add_source_info(mi: ModuleDecl, source_info: None | SourceInfo) -> None: ...

--- a/__macrotype__/macrotype/stubgen.pyi
+++ b/__macrotype__/macrotype/stubgen.pyi
@@ -1,38 +1,33 @@
 # Generated via: macrotype macrotype/stubgen.py -o __macrotype__/macrotype/stubgen.pyi
 # Do not edit by hand
 from __future__ import annotations
-
 from collections.abc import Sequence
-from pathlib import Path
-from types import ModuleType
-
+from macrotype.meta_types import patch_typing
 from macrotype.modules.ir import SourceInfo
+from macrotype.modules.source import extract_source_info, extract_type_checking_imports
+from pathlib import Path
 
-annotations = annotations
+class MypyPluginError(RuntimeError):
+    ...
+
+def _looks_like_mypy_plugin(name: str) -> bool: ...
 
 def _header_lines(command: None | str) -> list[str]: ...
-def _has_type_checking_guard(code: str) -> bool: ...
+
 def _module_name_from_path(path: Path) -> str: ...
+
 def load_module(name: str, allow_type_checking: bool) -> ModuleType: ...
+
 def load_module_from_code(code: str, name: str, allow_type_checking: bool) -> ModuleType: ...
+
 def stub_lines(module: ModuleType, source_info: None | SourceInfo, strict: bool) -> list[str]: ...
+
 def write_stub(dest: Path, lines: list[str], command: None | str) -> None: ...
-def process_module(
-    module: ModuleType,
-    dest: None | Path,
-    command: None | str,
-    strict: bool,
-    source_info: None | SourceInfo,
-) -> Path: ...
+
+def process_module(module: ModuleType, dest: None | Path, command: None | str, strict: bool, source_info: None | SourceInfo) -> Path: ...
+
 def iter_python_files(target: Path, skip: Sequence[str]) -> list[Path]: ...
-def process_file(
-    src: Path, dest: None | Path, command: None | str, strict: bool, allow_type_checking: bool
-) -> Path: ...
-def process_directory(
-    directory: Path,
-    out_dir: None | Path,
-    command: None | str,
-    strict: bool,
-    allow_type_checking: bool,
-    skip: Sequence[str],
-) -> list[Path]: ...
+
+def process_file(src: Path, dest: None | Path, command: None | str, strict: bool, allow_type_checking: bool) -> Path: ...
+
+def process_directory(directory: Path, out_dir: None | Path, command: None | str, strict: bool, allow_type_checking: bool, skip: Sequence[str]) -> list[Path]: ...

--- a/macrotype/cli/__main__.py
+++ b/macrotype/cli/__main__.py
@@ -61,9 +61,16 @@ def _stub_main(argv: list[str]) -> int:
 
     if args.paths == ["-"]:
         code = sys.stdin.read()
-        module = stubgen.load_module_from_code(code, "<stdin>", allow_type_checking=allow_tc)
-        header, comments, line_map = extract_source_info(code)
-        info = SourceInfo(headers=header, comments=comments, line_map=line_map)
+        header, comments, line_map, tc_imports = extract_source_info(
+            code, allow_type_checking=allow_tc
+        )
+        module = stubgen.load_module_from_code(code, "<stdin>", allow_type_checking=True)
+        info = SourceInfo(
+            headers=header,
+            comments=comments,
+            line_map=line_map,
+            tc_imports=tc_imports,
+        )
         lines = stubgen.stub_lines(module, source_info=info, strict=args.strict)
         if args.output and args.output != "-":
             stubgen.write_stub(Path(args.output), lines, command)
@@ -81,9 +88,16 @@ def _stub_main(argv: list[str]) -> int:
             if args.output == "-":
                 code = path.read_text()
                 module_name = stubgen._module_name_from_path(path)
-                module = stubgen.load_module(module_name, allow_type_checking=allow_tc)
-                header, comments, line_map = extract_source_info(code)
-                info = SourceInfo(headers=header, comments=comments, line_map=line_map)
+                header, comments, line_map, tc_imports = extract_source_info(
+                    code, allow_type_checking=allow_tc
+                )
+                module = stubgen.load_module(module_name, allow_type_checking=True)
+                info = SourceInfo(
+                    headers=header,
+                    comments=comments,
+                    line_map=line_map,
+                    tc_imports=tc_imports,
+                )
                 lines = stubgen.stub_lines(module, source_info=info, strict=args.strict)
                 _stdout_write(lines, command)
             else:

--- a/macrotype/modules/ir.py
+++ b/macrotype/modules/ir.py
@@ -97,6 +97,7 @@ class SourceInfo:
     headers: list[str]
     comments: dict[int, str]
     line_map: dict[str, int]
+    tc_imports: dict[str, set[str]] = field(default_factory=dict)
 
 
 @dataclass(kw_only=True)

--- a/macrotype/modules/transformers/resolve_imports.py
+++ b/macrotype/modules/transformers/resolve_imports.py
@@ -87,6 +87,10 @@ def resolve_imports(mi: ModuleDecl) -> None:
     for names in external.values():
         typing_names.difference_update(names)
 
+    existing = mi.imports
+    typing_names.update(existing.typing)
+    for mod, names in existing.froms.items():
+        external[mod].update(names)
     mi.imports = ImportBlock(typing=typing_names, froms=dict(external))
 
 

--- a/macrotype/modules/transformers/source_info.py
+++ b/macrotype/modules/transformers/source_info.py
@@ -8,6 +8,9 @@ from macrotype.modules.ir import ModuleDecl, SourceInfo
 def add_source_info(mi: ModuleDecl, source_info: SourceInfo | None = None) -> None:
     """Populate ``mi.source`` with provided source metadata."""
     mi.source = source_info or SourceInfo(headers=[], comments={}, line_map={})
+    if source_info is not None:
+        for mod, names in source_info.tc_imports.items():
+            mi.imports.froms.setdefault(mod, set()).update(names)
 
 
 __all__ = ["add_source_info"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ exclude = [
     "tests/annotations.pyi",
     "tests/annotations_new.pyi",
     "tests/typechecking.pyi",
+    "tests/typechecking_import_only.pyi",
     ".git",
     "macrotype/*.pyi",
     "__macrotype__",

--- a/tests/modules/test_source_info.py
+++ b/tests/modules/test_source_info.py
@@ -19,7 +19,7 @@ def test_source_info_attached(tmp_path: Path) -> None:
     finally:
         sys.path.remove(str(tmp_path))
         sys.modules.pop("source_info_mod", None)
-    header, comments, line_map = extract_source_info(code)
+    header, comments, line_map, _ = extract_source_info(code)
     info = SourceInfo(headers=header, comments=comments, line_map=line_map)
     mi = from_module(mod, source_info=info)
     assert mi.source is not None

--- a/tests/test_invalid_typing.py
+++ b/tests/test_invalid_typing.py
@@ -12,7 +12,7 @@ from macrotype.types.validate import TypeValidationError
 def test_invalid_literal_error():
     path = Path(__file__).with_name("annotations_invalid.py")
     mod = load_module("tests.annotations_invalid")
-    header, comments, line_map = extract_source_info(path.read_text())
+    header, comments, line_map, _ = extract_source_info(path.read_text())
     info = SourceInfo(headers=header, comments=comments, line_map=line_map)
     with pytest.raises(TypeValidationError) as exc:
         stub_lines(mod, source_info=info, strict=True)
@@ -25,7 +25,7 @@ def test_invalid_literal_error():
 def test_invalid_non_type_error():
     path = Path(__file__).with_name("annotations_invalid_non_type.py")
     mod = load_module("tests.annotations_invalid_non_type")
-    header, comments, line_map = extract_source_info(path.read_text())
+    header, comments, line_map, _ = extract_source_info(path.read_text())
     info = SourceInfo(headers=header, comments=comments, line_map=line_map)
     lines = stub_lines(mod, source_info=info, strict=True)
     assert lines[-1] == "BAD_NON_TYPE: 123"
@@ -42,7 +42,7 @@ def test_unresolved_string_kept_as_name(tmp_path):
     finally:
         sys.path.remove(str(tmp_path))
         sys.modules.pop("unresolved_mod", None)
-    header, comments, line_map = extract_source_info(code)
+    header, comments, line_map, _ = extract_source_info(code)
     info = SourceInfo(headers=header, comments=comments, line_map=line_map)
     lines = stub_lines(mod, source_info=info, strict=True)
     assert lines == ["X: Missing"]
@@ -58,7 +58,7 @@ def test_forward_ref_kept_as_name(tmp_path):
     finally:
         sys.path.remove(str(tmp_path))
         sys.modules.pop("forward_ref_mod", None)
-    header, comments, line_map = extract_source_info(code)
+    header, comments, line_map, _ = extract_source_info(code)
     info = SourceInfo(headers=header, comments=comments, line_map=line_map)
     lines = stub_lines(mod, source_info=info, strict=True)
     assert lines[0] == "from typing import Missing"
@@ -68,7 +68,7 @@ def test_forward_ref_kept_as_name(tmp_path):
 def test_misplaced_ellipsis_in_tuple_raises_error() -> None:
     path = Path(__file__).with_name("strict_error.py")
     mod = load_module("tests.strict_error")
-    header, comments, line_map = extract_source_info(path.read_text())
+    header, comments, line_map, _ = extract_source_info(path.read_text())
     info = SourceInfo(headers=header, comments=comments, line_map=line_map)
     with pytest.raises(TypeValidationError) as exc:
         stub_lines(mod, source_info=info, strict=True)

--- a/tests/test_type_checking.py
+++ b/tests/test_type_checking.py
@@ -17,8 +17,29 @@ def test_allow_type_checking_generates_runtime_stub() -> None:
     path = Path(__file__).with_name("typechecking.py")
     code = path.read_text()
     mod = load_module("tests.typechecking", allow_type_checking=True)
-    header, comments, line_map = extract_source_info(code)
-    info = SourceInfo(headers=header, comments=comments, line_map=line_map)
+    header, comments, line_map, tc_imports = extract_source_info(code, allow_type_checking=True)
+    info = SourceInfo(
+        headers=header,
+        comments=comments,
+        line_map=line_map,
+        tc_imports=tc_imports,
+    )
     lines = stub_lines(mod, source_info=info, strict=True)
     expected = Path(__file__).with_name("typechecking.pyi").read_text().splitlines()
+    assert lines == expected
+
+
+def test_simple_type_checking_imports() -> None:
+    path = Path(__file__).with_name("typechecking_import_only.py")
+    code = path.read_text()
+    mod = load_module("tests.typechecking_import_only")
+    header, comments, line_map, tc_imports = extract_source_info(code)
+    info = SourceInfo(
+        headers=header,
+        comments=comments,
+        line_map=line_map,
+        tc_imports=tc_imports,
+    )
+    lines = stub_lines(mod, source_info=info, strict=True)
+    expected = Path(__file__).with_name("typechecking_import_only.pyi").read_text().splitlines()
     assert lines == expected

--- a/tests/typechecking.pyi
+++ b/tests/typechecking.pyi
@@ -1,3 +1,5 @@
+from tests.annotations_new import Basic
+
 from typing import Any
 
 COS_ALIAS: Any

--- a/tests/typechecking_import_only.py
+++ b/tests/typechecking_import_only.py
@@ -1,0 +1,8 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from decimal import Decimal
+
+
+def uses_decimal(x: "Decimal") -> None:
+    pass

--- a/tests/typechecking_import_only.pyi
+++ b/tests/typechecking_import_only.pyi
@@ -1,0 +1,3 @@
+from decimal import Decimal
+
+def uses_decimal(x: Decimal) -> None: ...


### PR DESCRIPTION
## Summary
- parse TYPE_CHECKING guards and extract import-only blocks
- propagate collected imports through SourceInfo and resolve_imports
- allow modules with simple TYPE_CHECKING imports and test stub output

## Testing
- `ruff format`
- `ruff check --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a521c4c50c8329a933111d1be148bb