### PR TITLE
Preserve SQLAlchemy generic parameters in annotations

### DIFF
--- a/__macrotype__/macrotype/modules/__init__.pyi
+++ b/__macrotype__/macrotype/modules/__init__.pyi
@@ -1,14 +1,7 @@
-# Generated via: manual edit
+# Generated via: macrotype macrotype/modules/__init__.py -o __macrotype__/macrotype/modules/__init__.pyi
 # Do not edit by hand
 from __future__ import annotations
 
-from types import ModuleType
-
 from macrotype.modules.ir import ModuleDecl, SourceInfo
 
-def from_module(
-    mod: ModuleType,
-    *,
-    source_info: SourceInfo | None = ...,
-    strict: bool = ...,
-) -> ModuleDecl: ...
+def from_module(mod: ModuleType, source_info: None | SourceInfo, strict: bool) -> ModuleDecl: ...

--- a/__macrotype__/macrotype/modules/emit.pyi
+++ b/__macrotype__/macrotype/modules/emit.pyi
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from typing import Any, Iterable, ParamSpec, TypeVar, TypeVarTuple
 
-from macrotype.modules.ir import Decl, ModuleDecl
+from macrotype.modules.ir import (
+    Decl,
+    ModuleDecl,
+)
 
 INDENT: str
 

--- a/__macrotype__/macrotype/modules/ir.pyi
+++ b/__macrotype__/macrotype/modules/ir.pyi
@@ -1,10 +1,9 @@
 # Generated via: macrotype macrotype/modules/ir.py -o __macrotype__/macrotype/modules/ir.pyi
 # Do not edit by hand
 from __future__ import annotations
-from collections.abc import Iterator
-from dataclasses import dataclass, field
 
-from typing import Literal
+from dataclasses import dataclass
+from typing import Any, Iterator, Literal
 
 @dataclass(kw_only=True)
 class Decl:
@@ -12,17 +11,22 @@ class Decl:
     obj: EllipsisType | None | object
     comment: None | str
     emit: bool
-    def get_children(self) -> tuple['Decl', ...]: ...
+    def get_children(self) -> tuple["Decl", ...]: ...
     def get_annotation_sites(self) -> tuple[Site, ...]: ...
     def walk(self) -> Iterator[Decl]: ...
 
 @dataclass(kw_only=True)
 class Site:
-    role: Literal['var', 'return', 'param', 'base', 'alias_value', 'td_field']
+    role: Literal["var", "return", "param", "base", "alias_value", "td_field"]
     name: None | str
     index: None | int
     annotation: object
     comment: None | str
+
+@dataclass(frozen=True, kw_only=True)
+class AnnExpr:
+    expr: str
+    evaluated: Any
 
 @dataclass(kw_only=True)
 class VarDecl(Decl):

--- a/__macrotype__/macrotype/modules/scanner.pyi
+++ b/__macrotype__/macrotype/modules/scanner.pyi
@@ -2,15 +2,17 @@
 # Do not edit by hand
 from __future__ import annotations
 
-from types import ModuleType
 from typing import Any, Callable
 
-from macrotype.modules.ir import ClassDecl, FuncDecl, ModuleDecl
-
-annotations = annotations
+from macrotype.modules.ir import (
+    ClassDecl,
+    FuncDecl,
+    ModuleDecl,
+)
 
 def _eval_annotation(ann: Any, glb: dict[str, Any], lcl: None | dict[str, Any]) -> Any: ...
 def _is_dunder(name: str) -> bool: ...
 def scan_module(mod: ModuleType) -> ModuleDecl: ...
 def _scan_function(fn: Callable) -> FuncDecl: ...
+def _declared_bases_for_stub(cls: type) -> tuple[Any, ...]: ...
 def _scan_class(cls: type) -> ClassDecl: ...

--- a/__macrotype__/macrotype/types/__init__.pyi
+++ b/__macrotype__/macrotype/types/__init__.pyi
@@ -1,10 +1,8 @@
-# Generated via: macrotype macrotype
+# Generated via: macrotype macrotype/types/__init__.py -o __macrotype__/macrotype/types/__init__.pyi
 # Do not edit by hand
 from __future__ import annotations
 
 from macrotype.types.ir import Ty
-
-annotations = annotations
 
 def from_type(obj: object, ctx: str) -> Ty: ...
 def normalize_annotation(obj: object, ctx: str) -> object: ...

--- a/macrotype/modules/__init__.py
+++ b/macrotype/modules/__init__.py
@@ -100,10 +100,17 @@ def from_module(
     if strict:
         from macrotype.types import normalize_annotation
 
+        from .ir import AnnExpr
+
         for decl in mi.iter_all_decls():
             for site in decl.get_annotation_sites():
                 if site.role != "alias_value":
                     ctx = "call_params" if site.role == "param" else "top"
-                    site.annotation = normalize_annotation(site.annotation, ctx=ctx)
+                    ann = site.annotation
+                    if isinstance(ann, AnnExpr):
+                        norm = normalize_annotation(ann.evaluated, ctx=ctx)
+                        site.annotation = AnnExpr(expr=ann.expr, evaluated=norm)
+                    else:
+                        site.annotation = normalize_annotation(ann, ctx=ctx)
 
     return mi

--- a/macrotype/modules/emit.py
+++ b/macrotype/modules/emit.py
@@ -21,7 +21,7 @@ if hasattr(types, "UnionType"):
     _UNION_ORIGINS += (types.UnionType,)
 
 
-from .ir import ClassDecl, Decl, FuncDecl, ModuleDecl, TypeDefDecl, VarDecl
+from .ir import AnnExpr, ClassDecl, Decl, FuncDecl, ModuleDecl, TypeDefDecl, VarDecl
 
 
 def _qualname(obj: Any, default: str | None = None) -> str:
@@ -111,6 +111,9 @@ def flatten_annotation_atoms(ann: Any) -> dict[int, Any]:
 
     while stack:
         obj = stack.pop()
+        if isinstance(obj, AnnExpr):
+            stack.append(obj.evaluated)
+            continue
         obj_id = id(obj)
         if obj_id in visited:
             continue
@@ -212,6 +215,9 @@ def stringify_annotation(ann: Any, name_map: dict[int, str], module_name: str | 
     """Emit string form of a type annotation."""
     if ann is Ellipsis:
         return "..."
+
+    if isinstance(ann, AnnExpr):
+        return ann.expr
 
     if isinstance(ann, ForwardRef):
         return ann.__forward_arg__

--- a/macrotype/modules/ir.py
+++ b/macrotype/modules/ir.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from types import EllipsisType, ModuleType
-from typing import Iterator, Literal, Optional
+from typing import Any, Iterator, Literal, Optional
 
 
 @dataclass(kw_only=True)
@@ -33,6 +33,12 @@ class Site:
     index: Optional[int] = None
     annotation: object = None
     comment: str | None = None
+
+
+@dataclass(kw_only=True, frozen=True)
+class AnnExpr:
+    expr: str
+    evaluated: Any
 
 
 @dataclass(kw_only=True)

--- a/macrotype/types/__init__.py
+++ b/macrotype/types/__init__.py
@@ -25,6 +25,16 @@ def normalize_annotation(obj: object, *, ctx: str = "top") -> object:
     converted back into a Python typing object.
     """
 
+    from macrotype.modules.ir import AnnExpr
+
+    if isinstance(obj, AnnExpr):
+        # ``AnnExpr`` carries both the original textual annotation and the
+        # object produced by evaluating it.  This is needed for cases like
+        # SQLAlchemy where ``__class_getitem__`` drops generic parameters; the
+        # evaluated object alone would lose information.  Use the evaluated
+        # form for normalization while keeping the source text for later
+        # emission.
+        obj = obj.evaluated
     return unparse_top(from_type(obj, ctx=ctx))
 
 

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -45,6 +45,9 @@ from typing import (
     runtime_checkable,
 )
 
+from sqlalchemy.sql.selectable import Select as SASelect
+from sqlalchemy.sql.selectable import TypedReturnsRows as SATypedReturnsRows
+
 import macrotype.meta_types as mt
 from macrotype.meta_types import (
     emit_as,
@@ -1258,3 +1261,12 @@ def one[T1, T2, *Ts](query: TypedReturnsRows[tuple[T1, T2, *Ts]]) -> tuple[T1, T
 
 def one(query):
     return None
+
+
+# SQLAlchemy generics should preserve type arguments when used as parameters
+def count[T](query: "SASelect[tuple[T]]") -> int:
+    return 0
+
+
+def scalar[T](query: "SATypedReturnsRows[tuple[T]]") -> T:
+    raise NotImplementedError

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -38,6 +38,9 @@ from typing import (
     runtime_checkable,
 )
 
+from sqlalchemy.sql.selectable import Select as SASelect
+from sqlalchemy.sql.selectable import TypedReturnsRows as SATypedReturnsRows
+
 from macrotype.meta_types import (
     overload,
 )
@@ -691,6 +694,8 @@ def one[T1, T2, *Ts](
     query: TypedReturnsRows[tuple[T1, T2, Unpack[Ts]]],
 ) -> tuple[T1, T2, Unpack[Ts]]: ...
 def one(query): ...
+def count[T](query: SASelect[tuple[T]]) -> int: ...
+def scalar[T](query: SATypedReturnsRows[tuple[T]]) -> T: ...
 
 LITERAL_STR_VAR: LiteralString
 

--- a/tests/modules/test_emit_annotations.py
+++ b/tests/modules/test_emit_annotations.py
@@ -82,3 +82,15 @@ def test_generic_overload_preserves_params() -> None:
 
     line = next(text for text in lines if text.startswith("def one[T1, T2, *Ts]"))
     assert "TypedReturnsRows[tuple[T1, T2, Unpack[Ts]]]" in line
+
+
+def test_sqlalchemy_generics_in_parameters_preserved() -> None:
+    ann = import_module("tests.annotations_new")
+    mi = from_module(ann)
+    lines = emit_module(mi)
+
+    line = next(text for text in lines if text.startswith("def count["))
+    assert "SASelect[tuple[T]]" in line
+
+    line = next(text for text in lines if text.startswith("def scalar["))
+    assert "SATypedReturnsRows[tuple[T]]" in line


### PR DESCRIPTION
## Summary
- keep original type arguments when SQLAlchemy `Select` and `TypedReturnsRows` appear in annotations
- support new `AnnExpr` wrapper through scanning, normalization and emission
- add regression test for SQLAlchemy generics in parameter positions
- document why `AnnExpr` passthrough is needed when libraries discard generics via `__class_getitem__`

## Testing
- `python -m macrotype macrotype.modules.scanner macrotype.types`
- `ruff format macrotype/modules/scanner.py macrotype/types/__init__.py __macrotype__/macrotype/modules/scanner.pyi __macrotype__/macrotype/types/__init__.pyi`
- `ruff check --fix macrotype/modules/scanner.py macrotype/types/__init__.py`
- `pytest tests/modules/test_emit_annotations.py::test_generic_overload_preserves_params tests/modules/test_emit_annotations.py::test_sqlalchemy_generics_in_parameters_preserved -q`


------
https://chatgpt.com/codex/tasks/task_e_68a559195b1c83298935dcf99cbe8f73