### PR TITLE
Cache AST in SourceInfo

### DIFF
--- a/__macrotype__/macrotype/modules/ir.pyi
+++ b/__macrotype__/macrotype/modules/ir.pyi
@@ -2,6 +2,7 @@
 # Do not edit by hand
 from __future__ import annotations
 
+from ast import AST
 from dataclasses import dataclass
 from typing import Any, Iterator, Literal
 
@@ -74,6 +75,10 @@ class SourceInfo:
     comments: dict[int, str]
     line_map: dict[str, int]
     tc_imports: dict[str, set[str]]
+    code: None | str
+    _tree: AST | None
+    @property
+    def tree(self) -> AST: ...
 
 @dataclass(kw_only=True)
 class ImportBlock:

--- a/__macrotype__/macrotype/modules/source.pyi
+++ b/__macrotype__/macrotype/modules/source.pyi
@@ -1,16 +1,15 @@
 # Generated via: macrotype macrotype/modules/source.py -o __macrotype__/macrotype/modules/source.pyi
 # Do not edit by hand
 from __future__ import annotations
+
 from ast import AST
-from collections import defaultdict
 from re import Pattern
+
+from macrotype.modules.ir import SourceInfo
 
 PRAGMA_PREFIX = Pattern
 
 def _mentions_type_checking(expr: AST) -> bool: ...
-
 def _tc_imports_from_tree(tree: AST, allow_complex: bool) -> dict[str, set[str]]: ...
-
 def extract_type_checking_imports(code: str, allow_type_checking: bool) -> dict[str, set[str]]: ...
-
-def extract_source_info(code: str, allow_type_checking: bool) -> tuple[list[str], dict[int, str], dict[str, int], dict[str, set[str]]]: ...
+def extract_source_info(code: str, allow_type_checking: bool) -> SourceInfo: ...

--- a/__macrotype__/macrotype/modules/transformers/recover_custom_generics.pyi
+++ b/__macrotype__/macrotype/modules/transformers/recover_custom_generics.pyi
@@ -1,4 +1,4 @@
-# Generated via: macrotype macrotype -o __macrotype__/macrotype
+# Generated via: macrotype macrotype/modules/transformers/recover_custom_generics.py -o __macrotype__/macrotype/modules/transformers/recover_custom_generics.pyi
 # Do not edit by hand
 from __future__ import annotations
 

--- a/__macrotype__/macrotype/stubgen.pyi
+++ b/__macrotype__/macrotype/stubgen.pyi
@@ -1,33 +1,37 @@
 # Generated via: macrotype macrotype/stubgen.py -o __macrotype__/macrotype/stubgen.pyi
 # Do not edit by hand
 from __future__ import annotations
-from collections.abc import Sequence
-from macrotype.meta_types import patch_typing
-from macrotype.modules.ir import SourceInfo
-from macrotype.modules.source import extract_source_info, extract_type_checking_imports
-from pathlib import Path
 
-class MypyPluginError(RuntimeError):
-    ...
+from pathlib import Path
+from typing import Sequence
+
+from macrotype.modules.ir import SourceInfo
+
+class MypyPluginError(RuntimeError): ...
 
 def _looks_like_mypy_plugin(name: str) -> bool: ...
-
 def _header_lines(command: None | str) -> list[str]: ...
-
 def _module_name_from_path(path: Path) -> str: ...
-
 def load_module(name: str, allow_type_checking: bool) -> ModuleType: ...
-
 def load_module_from_code(code: str, name: str, allow_type_checking: bool) -> ModuleType: ...
-
 def stub_lines(module: ModuleType, source_info: None | SourceInfo, strict: bool) -> list[str]: ...
-
 def write_stub(dest: Path, lines: list[str], command: None | str) -> None: ...
-
-def process_module(module: ModuleType, dest: None | Path, command: None | str, strict: bool, source_info: None | SourceInfo) -> Path: ...
-
+def process_module(
+    module: ModuleType,
+    dest: None | Path,
+    command: None | str,
+    strict: bool,
+    source_info: None | SourceInfo,
+) -> Path: ...
 def iter_python_files(target: Path, skip: Sequence[str]) -> list[Path]: ...
-
-def process_file(src: Path, dest: None | Path, command: None | str, strict: bool, allow_type_checking: bool) -> Path: ...
-
-def process_directory(directory: Path, out_dir: None | Path, command: None | str, strict: bool, allow_type_checking: bool, skip: Sequence[str]) -> list[Path]: ...
+def process_file(
+    src: Path, dest: None | Path, command: None | str, strict: bool, allow_type_checking: bool
+) -> Path: ...
+def process_directory(
+    directory: Path,
+    out_dir: None | Path,
+    command: None | str,
+    strict: bool,
+    allow_type_checking: bool,
+    skip: Sequence[str],
+) -> list[Path]: ...

--- a/macrotype/cli/__main__.py
+++ b/macrotype/cli/__main__.py
@@ -5,7 +5,6 @@ import sys
 from pathlib import Path
 
 from .. import stubgen
-from ..modules.ir import SourceInfo
 from ..modules.source import extract_source_info
 from . import _default_output_path
 from .watch import watch_and_run
@@ -61,16 +60,8 @@ def _stub_main(argv: list[str]) -> int:
 
     if args.paths == ["-"]:
         code = sys.stdin.read()
-        header, comments, line_map, tc_imports = extract_source_info(
-            code, allow_type_checking=allow_tc
-        )
+        info = extract_source_info(code, allow_type_checking=allow_tc)
         module = stubgen.load_module_from_code(code, "<stdin>", allow_type_checking=True)
-        info = SourceInfo(
-            headers=header,
-            comments=comments,
-            line_map=line_map,
-            tc_imports=tc_imports,
-        )
         lines = stubgen.stub_lines(module, source_info=info, strict=args.strict)
         if args.output and args.output != "-":
             stubgen.write_stub(Path(args.output), lines, command)
@@ -88,16 +79,8 @@ def _stub_main(argv: list[str]) -> int:
             if args.output == "-":
                 code = path.read_text()
                 module_name = stubgen._module_name_from_path(path)
-                header, comments, line_map, tc_imports = extract_source_info(
-                    code, allow_type_checking=allow_tc
-                )
+                info = extract_source_info(code, allow_type_checking=allow_tc)
                 module = stubgen.load_module(module_name, allow_type_checking=True)
-                info = SourceInfo(
-                    headers=header,
-                    comments=comments,
-                    line_map=line_map,
-                    tc_imports=tc_imports,
-                )
                 lines = stubgen.stub_lines(module, source_info=info, strict=args.strict)
                 _stdout_write(lines, command)
             else:

--- a/macrotype/modules/ir.py
+++ b/macrotype/modules/ir.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 from dataclasses import dataclass, field
 from types import EllipsisType, ModuleType
 from typing import Any, Iterator, Literal, Optional
@@ -104,6 +105,16 @@ class SourceInfo:
     comments: dict[int, str]
     line_map: dict[str, int]
     tc_imports: dict[str, set[str]] = field(default_factory=dict)
+    code: str | None = None
+    _tree: ast.AST | None = field(default=None, init=False, repr=False)
+
+    @property
+    def tree(self) -> ast.AST:
+        if self._tree is None:
+            if self.code is None:
+                raise ValueError("No source code available for AST")
+            self._tree = ast.parse(self.code)
+        return self._tree
 
 
 @dataclass(kw_only=True)

--- a/macrotype/modules/source.py
+++ b/macrotype/modules/source.py
@@ -9,6 +9,8 @@ import tokenize
 from collections import defaultdict
 from typing import Dict, Set
 
+from .ir import SourceInfo
+
 # Comments matching this pattern are considered "pragma" headers that should be
 # preserved in generated stubs.  Other leading comments are treated as regular
 # source comments.
@@ -60,10 +62,8 @@ def extract_type_checking_imports(
     return _tc_imports_from_tree(tree, allow_complex=allow_type_checking)
 
 
-def extract_source_info(
-    code: str, *, allow_type_checking: bool = False
-) -> tuple[list[str], dict[int, str], dict[str, int], Dict[str, Set[str]]]:
-    """Return header comments, comment map, name line map, and TYPE_CHECKING imports."""
+def extract_source_info(code: str, *, allow_type_checking: bool = False) -> SourceInfo:
+    """Return SourceInfo for *code* including parsed AST."""
 
     comments: dict[int, str] = {}
     header: list[str] = []
@@ -99,7 +99,15 @@ def extract_source_info(
 
     tc_imports = _tc_imports_from_tree(tree, allow_complex=allow_type_checking)
 
-    return header, comments, line_map, tc_imports
+    info = SourceInfo(
+        headers=header,
+        comments=comments,
+        line_map=line_map,
+        tc_imports=tc_imports,
+        code=code,
+    )
+    info._tree = tree
+    return info
 
 
 __all__ = ["extract_source_info", "extract_type_checking_imports", "PRAGMA_PREFIX"]

--- a/macrotype/modules/transformers/recover_custom_generics.py
+++ b/macrotype/modules/transformers/recover_custom_generics.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import ast
 import typing as t
-from pathlib import Path
 
 from macrotype.modules.ir import AnnExpr, FuncDecl, ModuleDecl, VarDecl
 from macrotype.modules.scanner import _eval_annotation
@@ -78,13 +77,10 @@ def _apply_recover(
 
 
 def recover_custom_generics(mi: ModuleDecl) -> None:
-    if mi.source is None:
+    if mi.source is None or mi.source.code is None:
         return
-    file = getattr(mi.obj, "__file__", None)
-    if not file:
-        return
-    code = Path(file).read_text()
-    tree = ast.parse(code)
+    code = mi.source.code
+    tree = mi.source.tree
     var_map, param_map, ret_map = _build_maps(tree, code)
     glb = vars(mi.obj)
     fn_counts: dict[str, int] = {}

--- a/macrotype/stubgen.py
+++ b/macrotype/stubgen.py
@@ -142,21 +142,13 @@ def process_file(
 ) -> Path:
     code = src.read_text()
     try:
-        header, comments, line_map, tc_imports = extract_source_info(
-            code, allow_type_checking=allow_type_checking
-        )
+        info = extract_source_info(code, allow_type_checking=allow_type_checking)
     except RuntimeError:
         raise RuntimeError(f"Skipped {src} due to TYPE_CHECKING guard")
     module_name = _module_name_from_path(src)
     if _looks_like_mypy_plugin(module_name):
         raise MypyPluginError(f"{module_name} appears to be a mypy plugin")
     module = load_module(module_name, allow_type_checking=True)
-    info = SourceInfo(
-        headers=header,
-        comments=comments,
-        line_map=line_map,
-        tc_imports=tc_imports,
-    )
     dest = dest or src.with_suffix(".pyi")
     return process_module(
         module,

--- a/tests/modules/test_source_info.py
+++ b/tests/modules/test_source_info.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 
 from macrotype.modules import from_module
-from macrotype.modules.ir import SourceInfo
 from macrotype.modules.source import extract_source_info
 from macrotype.stubgen import load_module
 
@@ -19,10 +18,17 @@ def test_source_info_attached(tmp_path: Path) -> None:
     finally:
         sys.path.remove(str(tmp_path))
         sys.modules.pop("source_info_mod", None)
-    header, comments, line_map, _ = extract_source_info(code)
-    info = SourceInfo(headers=header, comments=comments, line_map=line_map)
+    info = extract_source_info(code)
     mi = from_module(mod, source_info=info)
     assert mi.source is not None
     assert mi.source.headers == ["# header1", "# header2"]
     assert mi.source.comments[1] == "# header1"
     assert mi.source.line_map["X"] == 3
+
+
+def test_source_info_tree_cached() -> None:
+    code = "X = 1\n"
+    info = extract_source_info(code)
+    first = info.tree
+    second = info.tree
+    assert first is second

--- a/tests/test_invalid_typing.py
+++ b/tests/test_invalid_typing.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pytest
 
-from macrotype.modules.ir import SourceInfo
 from macrotype.modules.source import extract_source_info
 from macrotype.stubgen import load_module, stub_lines
 from macrotype.types.validate import TypeValidationError
@@ -12,8 +11,7 @@ from macrotype.types.validate import TypeValidationError
 def test_invalid_literal_error():
     path = Path(__file__).with_name("annotations_invalid.py")
     mod = load_module("tests.annotations_invalid")
-    header, comments, line_map, _ = extract_source_info(path.read_text())
-    info = SourceInfo(headers=header, comments=comments, line_map=line_map)
+    info = extract_source_info(path.read_text())
     with pytest.raises(TypeValidationError) as exc:
         stub_lines(mod, source_info=info, strict=True)
     msg = str(exc.value)
@@ -25,8 +23,7 @@ def test_invalid_literal_error():
 def test_invalid_non_type_error():
     path = Path(__file__).with_name("annotations_invalid_non_type.py")
     mod = load_module("tests.annotations_invalid_non_type")
-    header, comments, line_map, _ = extract_source_info(path.read_text())
-    info = SourceInfo(headers=header, comments=comments, line_map=line_map)
+    info = extract_source_info(path.read_text())
     lines = stub_lines(mod, source_info=info, strict=True)
     assert lines[-1] == "BAD_NON_TYPE: 123"
     sys.modules.pop("tests.annotations_invalid_non_type", None)
@@ -42,8 +39,7 @@ def test_unresolved_string_kept_as_name(tmp_path):
     finally:
         sys.path.remove(str(tmp_path))
         sys.modules.pop("unresolved_mod", None)
-    header, comments, line_map, _ = extract_source_info(code)
-    info = SourceInfo(headers=header, comments=comments, line_map=line_map)
+    info = extract_source_info(code)
     lines = stub_lines(mod, source_info=info, strict=True)
     assert lines == ["X: Missing"]
 
@@ -58,8 +54,7 @@ def test_forward_ref_kept_as_name(tmp_path):
     finally:
         sys.path.remove(str(tmp_path))
         sys.modules.pop("forward_ref_mod", None)
-    header, comments, line_map, _ = extract_source_info(code)
-    info = SourceInfo(headers=header, comments=comments, line_map=line_map)
+    info = extract_source_info(code)
     lines = stub_lines(mod, source_info=info, strict=True)
     assert lines[0] == "from typing import Missing"
     assert lines[-1] == "X: Missing"
@@ -68,8 +63,7 @@ def test_forward_ref_kept_as_name(tmp_path):
 def test_misplaced_ellipsis_in_tuple_raises_error() -> None:
     path = Path(__file__).with_name("strict_error.py")
     mod = load_module("tests.strict_error")
-    header, comments, line_map, _ = extract_source_info(path.read_text())
-    info = SourceInfo(headers=header, comments=comments, line_map=line_map)
+    info = extract_source_info(path.read_text())
     with pytest.raises(TypeValidationError) as exc:
         stub_lines(mod, source_info=info, strict=True)
     msg = str(exc.value)

--- a/tests/test_type_checking.py
+++ b/tests/test_type_checking.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pytest
 
-from macrotype.modules.ir import SourceInfo
 from macrotype.modules.source import extract_source_info
 from macrotype.stubgen import load_module, stub_lines
 
@@ -17,13 +16,7 @@ def test_allow_type_checking_generates_runtime_stub() -> None:
     path = Path(__file__).with_name("typechecking.py")
     code = path.read_text()
     mod = load_module("tests.typechecking", allow_type_checking=True)
-    header, comments, line_map, tc_imports = extract_source_info(code, allow_type_checking=True)
-    info = SourceInfo(
-        headers=header,
-        comments=comments,
-        line_map=line_map,
-        tc_imports=tc_imports,
-    )
+    info = extract_source_info(code, allow_type_checking=True)
     lines = stub_lines(mod, source_info=info, strict=True)
     expected = Path(__file__).with_name("typechecking.pyi").read_text().splitlines()
     assert lines == expected
@@ -33,13 +26,7 @@ def test_simple_type_checking_imports() -> None:
     path = Path(__file__).with_name("typechecking_import_only.py")
     code = path.read_text()
     mod = load_module("tests.typechecking_import_only")
-    header, comments, line_map, tc_imports = extract_source_info(code)
-    info = SourceInfo(
-        headers=header,
-        comments=comments,
-        line_map=line_map,
-        tc_imports=tc_imports,
-    )
+    info = extract_source_info(code)
     lines = stub_lines(mod, source_info=info, strict=True)
     expected = Path(__file__).with_name("typechecking_import_only.pyi").read_text().splitlines()
     assert lines == expected


### PR DESCRIPTION
## Summary
- store source code and lazily parsed AST on SourceInfo
- expose extract_source_info as SourceInfo factory and reuse cached AST in transformers
- update CLI, stubgen, and tests for new SourceInfo API

## Testing
- `ruff format`
- `ruff check --fix __macrotype__/macrotype/modules/ir.pyi __macrotype__/macrotype/modules/source.pyi __macrotype__/macrotype/modules/transformers/recover_custom_generics.pyi __macrotype__/macrotype/stubgen.pyi macrotype/cli/__main__.py macrotype/modules/ir.py macrotype/modules/source.py macrotype/modules/transformers/recover_custom_generics.py macrotype/stubgen.py tests/modules/test_source_info.py tests/test_invalid_typing.py tests/test_type_checking.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a653476a588329bb637dcfdaf9f915