### PR TITLE
Expose eval_annotation for custom generic recovery

### DIFF
--- a/__macrotype__/macrotype/modules/scanner.pyi
+++ b/__macrotype__/macrotype/modules/scanner.pyi
@@ -2,6 +2,7 @@
 # Do not edit by hand
 from __future__ import annotations
 
+from types import ModuleType
 from typing import Any, Callable
 
 from macrotype.modules.ir import (
@@ -10,7 +11,7 @@ from macrotype.modules.ir import (
     ModuleDecl,
 )
 
-def _eval_annotation(ann: Any, glb: dict[str, Any], lcl: None | dict[str, Any]) -> Any: ...
+def eval_annotation(ann: Any, glb: dict[str, Any], lcl: None | dict[str, Any]) -> Any: ...
 def _is_dunder(name: str) -> bool: ...
 def scan_module(mod: ModuleType) -> ModuleDecl: ...
 def _scan_function(fn: Callable) -> FuncDecl: ...

--- a/macrotype/modules/transformers/recover_custom_generics.py
+++ b/macrotype/modules/transformers/recover_custom_generics.py
@@ -4,7 +4,7 @@ import ast
 import typing as t
 
 from macrotype.modules.ir import AnnExpr, FuncDecl, ModuleDecl, VarDecl
-from macrotype.modules.scanner import _eval_annotation
+from macrotype.modules.scanner import eval_annotation
 
 
 def _has_custom_class_getitem(obj: object) -> bool:
@@ -65,7 +65,7 @@ def _apply_recover(
 ) -> None:
     if not expr or "[" not in expr:
         return
-    new_ann = _eval_annotation(expr, glb, lcl)
+    new_ann = eval_annotation(expr, glb, lcl)
     if isinstance(new_ann, str):
         raise RuntimeError(
             f"Annotation for {name} uses non-standard __class_getitem__; switch to a string annotation"


### PR DESCRIPTION
## Summary
- Rename private `_eval_annotation` to public `eval_annotation`
- Remove wrapper and update scanner to call `eval_annotation`
- Regenerate stubs for updated scanner API

## Testing
- `ruff format macrotype/modules/scanner.py macrotype/modules/transformers/recover_custom_generics.py __macrotype__/macrotype/modules/scanner.pyi __macrotype__/macrotype/modules/transformers/recover_custom_generics.pyi`
- `ruff check --fix macrotype/modules/scanner.py macrotype/modules/transformers/recover_custom_generics.py __macrotype__/macrotype/modules/scanner.pyi __macrotype__/macrotype/modules/transformers/recover_custom_generics.pyi`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6802a35888329a369e7e220e31202