### PR TITLE
Add debug-failure option for stub generation

### DIFF
--- a/__macrotype__/macrotype/stubgen.pyi
+++ b/__macrotype__/macrotype/stubgen.pyi
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import ModuleType
 from typing import Sequence
 
 from macrotype.modules.ir import SourceInfo
@@ -34,4 +35,5 @@ def process_directory(
     strict: bool,
     allow_type_checking: bool,
     skip: Sequence[str],
+    debug_failure: bool,
 ) -> list[Path]: ...

--- a/macrotype/cli/__main__.py
+++ b/macrotype/cli/__main__.py
@@ -43,6 +43,11 @@ def _stub_main(argv: list[str]) -> int:
         action="store_true",
         help="Process modules guarded by TYPE_CHECKING",
     )
+    parser.add_argument(
+        "--debug-failure",
+        action="store_true",
+        help="Print stack trace and enter pdb on stub generation failure",
+    )
     args = parser.parse_args(argv)
     command = "macrotype " + " ".join(argv)
     allow_tc = args.allow_type_checking
@@ -102,6 +107,7 @@ def _stub_main(argv: list[str]) -> int:
                 command=command,
                 strict=args.strict,
                 allow_type_checking=allow_tc,
+                debug_failure=args.debug_failure,
             )
     return 0
 

--- a/macrotype/stubgen.py
+++ b/macrotype/stubgen.py
@@ -167,6 +167,7 @@ def process_directory(
     strict: bool = False,
     allow_type_checking: bool = False,
     skip: Sequence[str] = (),
+    debug_failure: bool = False,
 ) -> list[Path]:
     outputs: list[Path] = []
     for src in iter_python_files(directory, skip=skip):
@@ -192,7 +193,14 @@ def process_directory(
         except MypyPluginError as exc:
             print(f"Skipping {src}: {exc}", file=sys.stderr)
         except (Exception, SystemExit) as exc:  # pragma: no cover - defensive
-            print(f"Skipping {src}: {exc}", file=sys.stderr)
+            if debug_failure:
+                import pdb
+                import traceback
+
+                traceback.print_exception(type(exc), exc, exc.__traceback__)
+                pdb.post_mortem(exc.__traceback__)
+            else:
+                print(f"Skipping {src}: {exc}", file=sys.stderr)
     return outputs
 
 


### PR DESCRIPTION
## Summary
- Add `--debug-failure` flag to `macrotype` CLI to drop into `pdb` and print a stack trace when stub generation fails
- Support debugging failures in `stubgen.process_directory`

## Testing
- `ruff format macrotype/stubgen.py macrotype/cli/__main__.py __macrotype__/macrotype/stubgen.pyi`
- `ruff check --fix macrotype/stubgen.py macrotype/cli/__main__.py __macrotype__/macrotype/stubgen.pyi`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a78b402fd08329be170660ac3938f0