### PR TITLE
Add dataclass_transform import when emitting decorator

### DIFF
--- a/macrotype/modules/transformers/dataclass.py
+++ b/macrotype/modules/transformers/dataclass.py
@@ -53,6 +53,7 @@ def apply_dataclass_transform(mi: ModuleDecl) -> None:
             deco = _dt_decorator(cls)
             if deco:
                 sym.decorators = sym.decorators + (deco,)
+                mi.imports.typing.add("dataclass_transform")
             continue
         if has_transform(cls):
             sym.members = tuple(

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -39,7 +39,6 @@ from typing import (
     TypeVarTuple,
     Union,
     Unpack,
-    dataclass_transform,
     final,
     override,
     runtime_checkable,
@@ -1230,9 +1229,12 @@ BotBase.__orig_bases__ = (TopBase,)  # type: ignore[attr-defined]
 
 # dataclass_transform: carrier and subclass
 
+# dataclass_transform: attribute triggers decorator and import
 
-@dataclass_transform()
+
 class DCTransformBase:
+    __dataclass_transform__ = {}
+
     def __init_subclass__(cls) -> None:
         dataclass(cls)
 

--- a/tests/modules/transformers/test_transformers.py
+++ b/tests/modules/transformers/test_transformers.py
@@ -235,6 +235,24 @@ def test_dataclass_transform_carrier() -> None:
     assert "__init__" not in {m.name for m in sub.members}
 
 
+def test_dataclass_transform_import() -> None:
+    code = """
+    class Base:
+        __dataclass_transform__ = {}
+
+    class Sub(Base):
+        pass
+    """
+    mod = mod_from_code(code, "dc_transform_import")
+    mi = scan_module(mod)
+    transform_dataclasses(mi)
+    apply_dataclass_transform(mi)
+    by_name = {s.name: s for s in mi.members}
+    base = t.cast(ClassDecl, by_name["Base"])
+    assert "dataclass_transform()" in base.decorators
+    assert "dataclass_transform" in mi.imports.typing
+
+
 def test_descriptor_transform() -> None:
     code = """
     import functools


### PR DESCRIPTION
## Summary
- add typing import when `apply_dataclass_transform` emits the `dataclass_transform` decorator
- cover import generation for `__dataclass_transform__` carriers in annotations and unit tests

## Testing
- `python -m macrotype tests/annotations_new.py -o tests/annotations_new.pyi`
- `ruff format macrotype/modules/transformers/dataclass.py tests/annotations_new.py tests/modules/transformers/test_transformers.py`
- `ruff check --fix macrotype/modules/transformers/dataclass.py tests/annotations_new.py tests/modules/transformers/test_transformers.py`
- `pytest tests/modules/transformers/test_transformers.py::test_dataclass_transform_import tests/modules/transformers/test_transformers.py::test_dataclass_transform tests/modules/transformers/test_transformers.py::test_dataclass_transform_carrier -q`


------
https://chatgpt.com/codex/tasks/task_e_68a78b979b808329b4726de862bf6be5