### PR TITLE
Handle custom attribute access in scanner

### DIFF
--- a/macrotype/modules/transformers/newtype.py
+++ b/macrotype/modules/transformers/newtype.py
@@ -1,5 +1,6 @@
 """Convert typing.NewType functions into alias symbols."""
 
+import inspect
 import typing as t
 
 from macrotype.modules.ir import (
@@ -18,10 +19,14 @@ def _transform_decls(decls: list[Decl]) -> list[Decl]:
     for decl in decls:
         match decl:
             case FuncDecl(name=name, obj=obj, comment=comment, emit=emit):
-                if callable(obj) and hasattr(obj, "__supertype__"):
+                if (
+                    inspect.getattr_static(obj, "__call__", None) is not None
+                    and (supertype := inspect.getattr_static(obj, "__supertype__", None))
+                    is not None
+                ):
                     alias = TypeDefDecl(
                         name=name,
-                        value=Site(role="alias_value", annotation=obj.__supertype__),
+                        value=Site(role="alias_value", annotation=supertype),
                         obj_type=t.NewType,
                         comment=comment,
                         emit=emit,
@@ -31,10 +36,14 @@ def _transform_decls(decls: list[Decl]) -> list[Decl]:
                 else:
                     new_decls.append(decl)
             case VarDecl(name=name, obj=obj, comment=comment, emit=emit):
-                if callable(obj) and hasattr(obj, "__supertype__"):
+                if (
+                    inspect.getattr_static(obj, "__call__", None) is not None
+                    and (supertype := inspect.getattr_static(obj, "__supertype__", None))
+                    is not None
+                ):
                     alias = TypeDefDecl(
                         name=name,
-                        value=Site(role="alias_value", annotation=obj.__supertype__),
+                        value=Site(role="alias_value", annotation=supertype),
                         obj_type=t.NewType,
                         comment=comment,
                         emit=emit,

--- a/tests/annotations_new.py
+++ b/tests/annotations_new.py
@@ -87,6 +87,21 @@ ContravariantT = TypeVar("ContravariantT", contravariant=True)
 TDV = TypeVar("TDV")
 UserId = NewType("UserId", int)
 
+
+# Object that raises from __getattr__ for specific attributes to ensure safe
+# attribute access
+class RaisingProxy:
+    def __getattr__(self, name: str) -> typing.Any:
+        if name in {"__module__", "__supertype__"}:
+            raise RuntimeError("boom")
+        raise AttributeError(name)
+
+    def __call__(self) -> None:
+        pass
+
+
+RAISING_PROXY = RaisingProxy()
+
 # TypeScript-inspired metaclass utilities
 
 

--- a/tests/annotations_new.pyi
+++ b/tests/annotations_new.pyi
@@ -38,9 +38,22 @@ from typing import (
     runtime_checkable,
 )
 
-from sqlalchemy.engine.result import Result
+from sqlalchemy.engine import Result
+from sqlalchemy.engine import Result as SAResult
 from sqlalchemy.sql.selectable import (
-    TypedReturnsRows,
+    AliasedReturnsRows as SAAliasedReturnsRows,
+)
+from sqlalchemy.sql.selectable import (
+    ExecutableReturnsRows as SAExecutableReturnsRows,
+)
+from sqlalchemy.sql.selectable import (
+    ReturnsRows as SAReturnsRows,
+)
+from sqlalchemy.sql.selectable import (
+    Select as SASelect,
+)
+from sqlalchemy.sql.selectable import (
+    TypedReturnsRows as SATypedReturnsRows,
 )
 
 from macrotype.meta_types import (
@@ -65,6 +78,12 @@ ContravariantT = TypeVar("ContravariantT", contravariant=True)
 TDV = TypeVar("TDV")
 
 UserId = NewType("UserId", int)
+
+class RaisingProxy:
+    def __getattr__(self, name: str) -> Any: ...
+    def __call__(self) -> None: ...
+
+RAISING_PROXY: RaisingProxy
 
 def strip_null(ann: Any, null: Any) -> Any: ...
 


### PR DESCRIPTION
## Summary
- avoid triggering proxy objects while scanning modules and detecting NewType callables
- add regression test for objects overriding `__getattr__`

## Testing
- `ruff format macrotype/modules/scanner.py macrotype/modules/transformers/newtype.py tests/annotations_new.py tests/annotations_new.pyi`
- `ruff check --fix macrotype/modules/scanner.py macrotype/modules/transformers/newtype.py tests/annotations_new.py tests/annotations_new.pyi`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7971cf5b48329b76f2665ad75569a